### PR TITLE
Update ConcurrentLeafNode and ConcurrentWormhole to use QSBR

### DIFF
--- a/src/jmh/java/org/komamitsu/wormhole4j/jmh/benchmark/multithread/ConcurrentWormholeMultiThreadBenchmark.java
+++ b/src/jmh/java/org/komamitsu/wormhole4j/jmh/benchmark/multithread/ConcurrentWormholeMultiThreadBenchmark.java
@@ -81,6 +81,11 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
       public void register(FullState state) {
         state.map.registerThread();
       }
+
+      @TearDown(Level.Trial)
+      public void unregister(FullState state) {
+        state.map.unregisterThread();
+      }
     }
 
     @Group("PutAndGet")
@@ -131,6 +136,11 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
       @Setup(Level.Trial)
       public void register(FullState state) {
         state.map.registerThread();
+      }
+
+      @TearDown(Level.Trial)
+      public void unregister(ForIntKey.FullState state) {
+        state.map.unregisterThread();
       }
     }
 
@@ -188,6 +198,11 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
       @Setup(Level.Trial)
       public void register(FullState state) {
         state.map.registerThread();
+      }
+
+      @TearDown(Level.Trial)
+      public void unregister(ForIntKey.FullState state) {
+        state.map.unregisterThread();
       }
     }
 

--- a/src/jmh/java/org/komamitsu/wormhole4j/jmh/benchmark/multithread/ConcurrentWormholeMultiThreadBenchmark.java
+++ b/src/jmh/java/org/komamitsu/wormhole4j/jmh/benchmark/multithread/ConcurrentWormholeMultiThreadBenchmark.java
@@ -38,9 +38,11 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
 
     protected void setup(Wormhole<K, Integer> wormhole, KeysState<K> keysState) {
       map = wormhole;
+      map.register();
       for (K key : keysState.keys) {
         map.put(key, randomInt());
       }
+      map.unregister();
     }
   }
 
@@ -73,10 +75,19 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
       }
     }
 
+    @State(Scope.Thread)
+    public static class ThreadState {
+      @Setup(Level.Trial)
+      public void register(FullState state) {
+        state.map.register();
+      }
+    }
+
     @Group("PutAndGet")
     @GroupThreads(4)
     @Benchmark
-    public void putAndGetBenchmarkPut(IntKeysState keysState, FullState fullState) {
+    public void putAndGetBenchmarkPut(
+        IntKeysState keysState, FullState fullState, ThreadState threadState) {
       execPut(keysState, fullState);
     }
 
@@ -84,14 +95,15 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
     @GroupThreads(4)
     @Benchmark
     public void putAndGetBenchmarkGet(
-        IntKeysState keysState, FullState fullState, Blackhole blackhole) {
+        IntKeysState keysState, FullState fullState, Blackhole blackhole, ThreadState threadState) {
       execGet(keysState, fullState, blackhole);
     }
 
     @Group("PutAndScan")
     @GroupThreads(4)
     @Benchmark
-    public void putAndScanBenchmarkPut(IntKeysState keysState, FullState fullState) {
+    public void putAndScanBenchmarkPut(
+        IntKeysState keysState, FullState fullState, ThreadState threadState) {
       execPut(keysState, fullState);
     }
 
@@ -99,7 +111,7 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
     @GroupThreads(4)
     @Benchmark
     public void putAndScanBenchmarkScan(
-        IntKeysState keysState, FullState fullState, Blackhole blackhole) {
+        IntKeysState keysState, FullState fullState, Blackhole blackhole, ThreadState threadState) {
       execScan(keysState, fullState, blackhole);
     }
   }
@@ -114,10 +126,19 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
       }
     }
 
+    @State(Scope.Thread)
+    public static class ThreadState {
+      @Setup(Level.Trial)
+      public void register(FullState state) {
+        state.map.register();
+      }
+    }
+
     @Group("PutAndGet")
     @GroupThreads(4)
     @Benchmark
-    public void putAndGetBenchmarkPut(LongKeysState keysState, FullState fullState) {
+    public void putAndGetBenchmarkPut(
+        LongKeysState keysState, FullState fullState, ThreadState threadState) {
       execPut(keysState, fullState);
     }
 
@@ -125,14 +146,18 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
     @GroupThreads(4)
     @Benchmark
     public void putAndGetBenchmarkGet(
-        LongKeysState keysState, FullState fullState, Blackhole blackhole) {
+        LongKeysState keysState,
+        FullState fullState,
+        Blackhole blackhole,
+        ThreadState threadState) {
       execGet(keysState, fullState, blackhole);
     }
 
     @Group("PutAndScan")
     @GroupThreads(4)
     @Benchmark
-    public void putAndScanBenchmarkPut(LongKeysState keysState, FullState fullState) {
+    public void putAndScanBenchmarkPut(
+        LongKeysState keysState, FullState fullState, ThreadState threadState) {
       execPut(keysState, fullState);
     }
 
@@ -140,7 +165,10 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
     @GroupThreads(4)
     @Benchmark
     public void putAndScanBenchmarkScan(
-        LongKeysState keysState, FullState fullState, Blackhole blackhole) {
+        LongKeysState keysState,
+        FullState fullState,
+        Blackhole blackhole,
+        ThreadState threadState) {
       execScan(keysState, fullState, blackhole);
     }
   }
@@ -155,10 +183,19 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
       }
     }
 
+    @State(Scope.Thread)
+    public static class ThreadState {
+      @Setup(Level.Trial)
+      public void register(FullState state) {
+        state.map.register();
+      }
+    }
+
     @Group("PutAndGet")
     @GroupThreads(4)
     @Benchmark
-    public void putAndGetBenchmarkPut(StringKeysState keysState, FullState fullState) {
+    public void putAndGetBenchmarkPut(
+        StringKeysState keysState, FullState fullState, ThreadState threadState) {
       execPut(keysState, fullState);
     }
 
@@ -166,14 +203,18 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
     @GroupThreads(4)
     @Benchmark
     public void putAndGetBenchmarkGet(
-        StringKeysState keysState, FullState fullState, Blackhole blackhole) {
+        StringKeysState keysState,
+        FullState fullState,
+        Blackhole blackhole,
+        ThreadState threadState) {
       execGet(keysState, fullState, blackhole);
     }
 
     @Group("PutAndScan")
     @GroupThreads(4)
     @Benchmark
-    public void putAndScanBenchmarkPut(StringKeysState keysState, FullState fullState) {
+    public void putAndScanBenchmarkPut(
+        StringKeysState keysState, FullState fullState, ThreadState threadState) {
       execPut(keysState, fullState);
     }
 
@@ -181,7 +222,10 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
     @GroupThreads(4)
     @Benchmark
     public void putAndScanBenchmarkScan(
-        StringKeysState keysState, FullState fullState, Blackhole blackhole) {
+        StringKeysState keysState,
+        FullState fullState,
+        Blackhole blackhole,
+        ThreadState threadState) {
       execScan(keysState, fullState, blackhole);
     }
   }

--- a/src/jmh/java/org/komamitsu/wormhole4j/jmh/benchmark/multithread/ConcurrentWormholeMultiThreadBenchmark.java
+++ b/src/jmh/java/org/komamitsu/wormhole4j/jmh/benchmark/multithread/ConcurrentWormholeMultiThreadBenchmark.java
@@ -38,11 +38,11 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
 
     protected void setup(Wormhole<K, Integer> wormhole, KeysState<K> keysState) {
       map = wormhole;
-      map.register();
+      map.registerThread();
       for (K key : keysState.keys) {
         map.put(key, randomInt());
       }
-      map.unregister();
+      map.unregisterThread();
     }
   }
 
@@ -79,7 +79,7 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
     public static class ThreadState {
       @Setup(Level.Trial)
       public void register(FullState state) {
-        state.map.register();
+        state.map.registerThread();
       }
     }
 
@@ -130,7 +130,7 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
     public static class ThreadState {
       @Setup(Level.Trial)
       public void register(FullState state) {
-        state.map.register();
+        state.map.registerThread();
       }
     }
 
@@ -187,7 +187,7 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
     public static class ThreadState {
       @Setup(Level.Trial)
       public void register(FullState state) {
-        state.map.register();
+        state.map.registerThread();
       }
     }
 

--- a/src/jmh/java/org/komamitsu/wormhole4j/jmh/benchmark/multithread/ConcurrentWormholeMultiThreadBenchmark.java
+++ b/src/jmh/java/org/komamitsu/wormhole4j/jmh/benchmark/multithread/ConcurrentWormholeMultiThreadBenchmark.java
@@ -139,7 +139,7 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
       }
 
       @TearDown(Level.Trial)
-      public void unregister(ForIntKey.FullState state) {
+      public void unregister(FullState state) {
         state.map.unregisterThread();
       }
     }
@@ -201,7 +201,7 @@ public abstract class ConcurrentWormholeMultiThreadBenchmark<K extends Comparabl
       }
 
       @TearDown(Level.Trial)
-      public void unregister(ForIntKey.FullState state) {
+      public void unregister(FullState state) {
         state.map.unregisterThread();
       }
     }

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentLeafNode.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentLeafNode.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
 
 class ConcurrentLeafNode<K, V> extends LeafNode<K, V> {
   private final StampedLock lock = new StampedLock();
-  private Long initialLockStamp;
+  private long initialLockStamp;
   private long version;
 
   ConcurrentLeafNode(
@@ -76,7 +76,7 @@ class ConcurrentLeafNode<K, V> extends LeafNode<K, V> {
   }
 
   @Override
-  protected LeafNode<K, V> createLeafNode(
+  protected LeafNode<K, V> createLeafNodeForSplit(
       EncodedKeyType encodedKeyType,
       Function<Object, Object> validAnchorKeyProvider,
       Object anchorKey,

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentLeafNode.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentLeafNode.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 
 class ConcurrentLeafNode<K, V> extends LeafNode<K, V> {
   private final StampedLock lock = new StampedLock();
+  private long version;
 
   ConcurrentLeafNode(
       EncodedKeyType encodedKeyType,
@@ -43,8 +44,19 @@ class ConcurrentLeafNode<K, V> extends LeafNode<K, V> {
     return lock.readLock();
   }
 
+  @Override
   void releaseLock(long stamp) {
     this.lock.unlock(stamp);
+  }
+
+  @Override
+  long getVersion() {
+    return version;
+  }
+
+  @Override
+  void setVersion(long version) {
+    this.version = version;
   }
 
   @Override

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentLeafNode.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentLeafNode.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 
 class ConcurrentLeafNode<K, V> extends LeafNode<K, V> {
+  private static final long TRY_LOCK_WAIT_IN_MILLIS = 5;
   private final StampedLock lock = new StampedLock();
   private Long initialLockStamp;
   private long version;
@@ -49,8 +50,7 @@ class ConcurrentLeafNode<K, V> extends LeafNode<K, V> {
   @Override
   long tryReadLock() {
     try {
-      // TODO: Consider no wait.
-      return lock.tryReadLock(5, TimeUnit.MILLISECONDS);
+      return lock.tryReadLock(TRY_LOCK_WAIT_IN_MILLIS, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new RuntimeException(e);
@@ -60,8 +60,7 @@ class ConcurrentLeafNode<K, V> extends LeafNode<K, V> {
   @Override
   long tryWriteLock() {
     try {
-      // TODO: Consider no wait.
-      return lock.tryWriteLock(5, TimeUnit.MILLISECONDS);
+      return lock.tryWriteLock(TRY_LOCK_WAIT_IN_MILLIS, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new RuntimeException(e);

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentLeafNode.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentLeafNode.java
@@ -16,12 +16,14 @@
 
 package org.komamitsu.wormhole4j;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
 class ConcurrentLeafNode<K, V> extends LeafNode<K, V> {
   private final StampedLock lock = new StampedLock();
+  private Long initialLockStamp;
   private long version;
 
   ConcurrentLeafNode(
@@ -45,8 +47,35 @@ class ConcurrentLeafNode<K, V> extends LeafNode<K, V> {
   }
 
   @Override
+  long tryReadLock() {
+    try {
+      // TODO: Consider no wait.
+      return lock.tryReadLock(5, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  long tryWriteLock() {
+    try {
+      // TODO: Consider no wait.
+      return lock.tryWriteLock(5, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
   void releaseLock(long stamp) {
     this.lock.unlock(stamp);
+  }
+
+  @Override
+  long getInitialLockStamp() {
+    return initialLockStamp;
   }
 
   @Override
@@ -67,7 +96,10 @@ class ConcurrentLeafNode<K, V> extends LeafNode<K, V> {
       int maxSize,
       @Nullable LeafNode<K, V> left,
       @Nullable LeafNode<K, V> right) {
-    return new ConcurrentLeafNode<>(
-        encodedKeyType, validAnchorKeyProvider, anchorKey, maxSize, left, right);
+    ConcurrentLeafNode<K, V> leafNode =
+        new ConcurrentLeafNode<>(
+            encodedKeyType, validAnchorKeyProvider, anchorKey, maxSize, left, right);
+    leafNode.initialLockStamp = leafNode.acquireWriteLock();
+    return leafNode;
   }
 }

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentLeafNode.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentLeafNode.java
@@ -16,13 +16,11 @@
 
 package org.komamitsu.wormhole4j;
 
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
 class ConcurrentLeafNode<K, V> extends LeafNode<K, V> {
-  private static final long TRY_LOCK_WAIT_IN_MILLIS = 5;
   private final StampedLock lock = new StampedLock();
   private Long initialLockStamp;
   private long version;
@@ -49,22 +47,12 @@ class ConcurrentLeafNode<K, V> extends LeafNode<K, V> {
 
   @Override
   long tryReadLock() {
-    try {
-      return lock.tryReadLock(TRY_LOCK_WAIT_IN_MILLIS, TimeUnit.MILLISECONDS);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException(e);
-    }
+    return lock.tryReadLock();
   }
 
   @Override
   long tryWriteLock() {
-    try {
-      return lock.tryWriteLock(TRY_LOCK_WAIT_IN_MILLIS, TimeUnit.MILLISECONDS);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException(e);
-    }
+    return lock.tryWriteLock();
   }
 
   @Override

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -203,7 +203,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     while (true) {
       qsbrEnter();
       LeafNode<K, V> leafNode = searchTrieHashTable(qsbrThreadLocalMetaTables.get(), encodedKey);
-      Long writeLockOnLeafNode = leafNode.tryWriteLock();
+      long writeLockOnLeafNode = leafNode.tryWriteLock();
       if (writeLockOnLeafNode == 0) {
         qsbrExit();
         continue;
@@ -224,8 +224,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
           long newVersion = version + 1;
 
           // This new leaf is already locked.
-          LeafNode<K, V> newLeafNode =
-              splitLeafNode(getInactiveMetaTable(), leafNode, encodedKey, key, value);
+          LeafNode<K, V> newLeafNode = splitLeafNode(leafNode, encodedKey, key, value);
           addNewLeafNodeToMetaTable(getInactiveMetaTable(), newLeafNode);
 
           // Increment versions and switch to the updated meta table.
@@ -234,7 +233,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
           switchMetaTable(newVersion);
           newLeafNode.releaseLock(newLeafNode.getInitialLockStamp());
           leafNode.releaseLock(writeLockOnLeafNode);
-          writeLockOnLeafNode = null;
+          writeLockOnLeafNode = 0;
 
           // Wait until no reader threads on the previously active meta table.
           qsbrThreadLocalVersions.get().set(newVersion);
@@ -247,7 +246,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
         }
       } finally {
         qsbrExit();
-        if (writeLockOnLeafNode != null) {
+        if (writeLockOnLeafNode != 0) {
           leafNode.releaseLock(writeLockOnLeafNode);
         }
       }
@@ -266,7 +265,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     while (true) {
       qsbrEnter();
       LeafNode<K, V> leafNode = searchTrieHashTable(qsbrThreadLocalMetaTables.get(), encodedKey);
-      Long writeLockOnLeafNode = leafNode.tryWriteLock();
+      long writeLockOnLeafNode = leafNode.tryWriteLock();
       if (writeLockOnLeafNode == 0) {
         qsbrExit();
         continue;
@@ -303,7 +302,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
           }
           switchMetaTable(newVersion);
           leafNode.releaseLock(writeLockOnLeafNode);
-          writeLockOnLeafNode = null;
+          writeLockOnLeafNode = 0;
 
           // Wait until no reader threads on the previously active meta table.
           qsbrThreadLocalVersions.get().set(newVersion);
@@ -318,7 +317,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
         }
       } finally {
         qsbrExit();
-        if (writeLockOnLeafNode != null) {
+        if (writeLockOnLeafNode != 0) {
           leafNode.releaseLock(writeLockOnLeafNode);
         }
       }

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -220,7 +220,6 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
         if (existingValue != null) {
           return existingValue.orElse(null);
         }
-        qsbrExit();
         long writeLockOnMetaTable = tryLockOnMetaTable();
         if (writeLockOnMetaTable == 0) {
           continue;
@@ -298,6 +297,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
             mergedLeafNode = mergedLeafNodes.second;
             removeMergedLeafNodeFromMetaTable(getInactiveMetaTable(), mergedLeafNode);
           }
+
           // Increment versions and switch to the updated meta table.
           long newVersion = version + 1;
           leafNode.setVersion(newVersion);
@@ -307,6 +307,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
           switchMetaTable(newVersion);
           leafNode.releaseLock(writeLockOnLeafNode);
           writeLockOnLeafNode = null;
+
           // Wait until no reader threads on the previously active meta table.
           qsbrThreadLocalVersions.get().set(newVersion);
           qsbrWait(newVersion, getQsbrThreadIndex());

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -184,21 +184,23 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
       long writeLockOnMetaTable = acquireLockOnMetaTable();
       try {
         long newVersion = version + 1;
-        // Split the node and insert the value to a new leaf node on the inactive meta table.
+
         LeafNode<K, V> newLeafNode =
-            splitAndInsert(getInactiveMetaTable(), leafNode, encodedKey, key, value);
+            splitLeafNode(getInactiveMetaTable(), leafNode, encodedKey, key, value);
+        addNewLeafNodeToMetaTable(getInactiveMetaTable(), newLeafNode);
+
         // Increment versions and switch to the updated meta table.
         leafNode.setVersion(newVersion);
         newLeafNode.setVersion(newVersion);
         switchMetaTable(newVersion);
         leafNode.releaseLock(writeLockOnLeafNode);
         writeLockOnLeafNode = null;
+
         // Wait until no reader threads on the previously active meta table.
         qsbrExit();
         qsbrWait(newVersion);
-        // Split the node and insert the value to a new leaf node on the inactive (previously
-        // active) meta table.
-        splitAndInsert(getInactiveMetaTable(), leafNode, encodedKey, key, value);
+
+        addNewLeafNodeToMetaTable(getInactiveMetaTable(), newLeafNode);
         return null;
       } finally {
         releaseLockOnMetaTable(writeLockOnMetaTable);

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -36,6 +36,7 @@ import org.komamitsu.wormhole4j.MetaTrieHashTable.NodeMetaLeaf;
 abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   // TODO: Make this configurable.
   private static final int MAX_THREADS = 512;
+  // These don't need to be volatile since they are only updated in synchronized blocks.
   private int metaTableIndex;
   private long version;
   private final List<MetaTrieHashTable<K, V>> metaTables;

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -114,13 +114,21 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   }
 
   private void qsbrEnter() {
-    qsbrThreadLocalVersions.get().set(version);
+    AtomicReference<Long> qsbrThreadLocalVersion = qsbrThreadLocalVersions.get();
+    if (qsbrThreadLocalVersion == null) {
+      throw new IllegalStateException("This thread is not registered yet");
+    }
+    qsbrThreadLocalVersion.set(version);
     qsbrThreadLocalMetaTables.set(getMetaTable());
   }
 
   private void qsbrExit() {
+    AtomicReference<Long> qsbrThreadLocalVersion = qsbrThreadLocalVersions.get();
+    if (qsbrThreadLocalVersion == null) {
+      throw new IllegalStateException("This thread is not registered yet");
+    }
     qsbrThreadLocalMetaTables.remove();
-    qsbrThreadLocalVersions.get().set(null);
+    qsbrThreadLocalVersion.set(null);
   }
 
   private long getLocalVersion() {

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -130,7 +130,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     if (qsbrThreadLocalVersion == null) {
       throw new IllegalStateException("This thread is not registered yet");
     }
-    qsbrThreadLocalMetaTables.remove();
+    qsbrThreadLocalMetaTables.set(null);
     qsbrThreadLocalVersion.set(null);
   }
 

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -232,7 +232,14 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
       long writeLockOnMetaTable = acquireLockOnMetaTable();
       try {
         // Merge the nodes on the inactive meta table if needed.
-        LeafNode<K, V> updatedLeafNode = mergeIfNeeded(getInactiveMetaTable(), leafNode);
+        Tuple<LeafNode<K, V>, LeafNode<K, V>> mergedLeafNodes = mergeLeafNodesIfNeeded(leafNode);
+        LeafNode<K, V> updatedLeafNode = null;
+        LeafNode<K, V> mergedLeafNode = null;
+        if (mergedLeafNodes != null) {
+          updatedLeafNode = mergedLeafNodes.first;
+          mergedLeafNode = mergedLeafNodes.second;
+          removeMergedLeafNodeFromMetaTable(getInactiveMetaTable(), mergedLeafNode);
+        }
         // Increment versions and switch to the updated meta table.
         long newVersion = version + 1;
         leafNode.setVersion(newVersion);
@@ -245,8 +252,10 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
         // Wait until no reader threads on the previously active meta table.
         qsbrExit();
         qsbrWait(newVersion);
-        // Merge the nodes on the inactive (previously active) meta table if needed.
-        mergeIfNeeded(getInactiveMetaTable(), leafNode);
+        // Remove the merged leaf node from the inactive meta table.
+        if (mergedLeafNode != null) {
+          removeMergedLeafNodeFromMetaTable(getInactiveMetaTable(), mergedLeafNode);
+        }
         return true;
       } finally {
         releaseLockOnMetaTable(writeLockOnMetaTable);
@@ -300,42 +309,40 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     Object encodedEndKey = endKey == null ? null : createEncodedKey(endKey);
     BiFunction<K, V, Boolean> actualFunction = prepareScanFunction(count, function);
 
-    while (true) {
+    try {
       qsbrEnter();
-      try {
-        LeafNode<K, V> leafNode = searchTrieHashTable(encodedStartKey);
-        while (leafNode != null) {
-          long lockOnLeafNode;
-          boolean writeLockOnLeafNode = false;
-          while (true) {
-            lockOnLeafNode =
-                writeLockOnLeafNode ? leafNode.acquireWriteLock() : leafNode.acquireReadLock();
-            if (writeLockOnLeafNode || leafNode.isKeyRefsSorted()) {
-              break;
-            }
-            leafNode.releaseLock(lockOnLeafNode);
-            writeLockOnLeafNode = true;
+      LeafNode<K, V> leafNode = searchTrieHashTable(encodedStartKey);
+      while (leafNode != null) {
+        long lockOnLeafNode;
+        boolean writeLockOnLeafNode = false;
+        while (true) {
+          lockOnLeafNode =
+              writeLockOnLeafNode ? leafNode.acquireWriteLock() : leafNode.acquireReadLock();
+          if (writeLockOnLeafNode || leafNode.isKeyRefsSorted()) {
+            break;
           }
-          try {
-            if (leafNode.getVersion() > getLocalVersion()) {
-              // FIXME: This break leads to a retry from the beginning, but `actualFunction` can be
-              // executed multiple times on the same leaf nodes...
-              break;
-            }
-            leafNode.incSort();
-            if (!leafNode.iterateKeyValues(
-                encodedStartKey, encodedEndKey, isEndKeyExclusive, actualFunction)) {
-              return;
-            }
-          } finally {
-            leafNode.releaseLock(lockOnLeafNode);
-          }
-          leafNode = leafNode.getRight();
-          encodedStartKey = null;
+          leafNode.releaseLock(lockOnLeafNode);
+          writeLockOnLeafNode = true;
         }
-      } finally {
-        qsbrExit();
+        try {
+          if (leafNode.getVersion() > getLocalVersion()) {
+            // FIXME: This break leads to a retry from the beginning, but `actualFunction` can be
+            //        executed multiple times on the same leaf nodes...
+            break;
+          }
+          leafNode.incSort();
+          if (!leafNode.iterateKeyValues(
+              encodedStartKey, encodedEndKey, isEndKeyExclusive, actualFunction)) {
+            return;
+          }
+        } finally {
+          leafNode.releaseLock(lockOnLeafNode);
+        }
+        leafNode = leafNode.getRight();
+        encodedStartKey = null;
       }
+    } finally {
+      qsbrExit();
     }
   }
 

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -79,22 +79,24 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   }
 
   protected MetaTrieHashTable<K, V> getInactiveMetaTable() {
-    return metaTables.get(metaTableIndex);
+    return metaTables.get(getInactiveMetaTableIndex());
   }
 
   private int getQsbrThreadIndex() {
     return qsbrThreadLocalIndexes.get();
   }
 
+  @Override
   public synchronized void register() {
     int availableThreadIndex = qsbrThreads.nextClearBit(0);
     AtomicReference<Long> versionContainer = new AtomicReference<>();
     qsbrThreadLocalIndexes.set(availableThreadIndex);
     qsbrThreadLocalVersions.set(versionContainer);
     qsbrThreads.set(availableThreadIndex);
-    qsbrVersions.set(availableThreadIndex, versionContainer);
+    registerQsbrVersion(availableThreadIndex, versionContainer);
   }
 
+  @Override
   public synchronized void unregister() {
     int qsbrThreadIndex = getQsbrThreadIndex();
     qsbrVersions.set(qsbrThreadIndex, null);
@@ -102,6 +104,13 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     qsbrThreadLocalMetaTables.remove();
     qsbrThreadLocalVersions.remove();
     qsbrThreadLocalIndexes.remove();
+  }
+
+  private void registerQsbrVersion(int threadIndex, AtomicReference<Long> versionContainer) {
+    while (qsbrVersions.size() <= threadIndex) {
+      qsbrVersions.add(null);
+    }
+    qsbrVersions.set(threadIndex, versionContainer);
   }
 
   private void qsbrEnter() {
@@ -131,6 +140,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
           break;
         }
       }
+      threadIndex++;
     }
   }
 

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -17,6 +17,7 @@
 package org.komamitsu.wormhole4j;
 
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.BiFunction;
@@ -89,6 +90,9 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   @Override
   public synchronized void register() {
     int availableThreadIndex = qsbrThreads.nextClearBit(0);
+    if (availableThreadIndex >= MAX_THREADS) {
+      throw new IllegalStateException("The number of registered threads exceeds " + MAX_THREADS);
+    }
     AtomicReference<Long> versionContainer = new AtomicReference<>();
     qsbrThreadLocalIndexes.set(availableThreadIndex);
     qsbrThreadLocalVersions.set(versionContainer);
@@ -104,6 +108,11 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     qsbrThreadLocalMetaTables.remove();
     qsbrThreadLocalVersions.remove();
     qsbrThreadLocalIndexes.remove();
+  }
+
+  @Override
+  public boolean isThreadRegistered() {
+    return qsbrThreadLocalIndexes.get() != null;
   }
 
   private void registerQsbrVersion(int threadIndex, AtomicReference<Long> versionContainer) {
@@ -152,12 +161,26 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     }
   }
 
-  private long acquireLockOnMetaTable() {
+  private long tryLockOnMetaTable() {
+    try {
+      // TODO: Consider no wait.
+      return metaTableLock.tryWriteLock(5, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+
+  private long acquireReadLockOnMetaTable() {
+    return metaTableLock.readLock();
+  }
+
+  private long acquireWriteLockOnMetaTable() {
     return metaTableLock.writeLock();
   }
 
   private void releaseLockOnMetaTable(long stamp) {
-    metaTableLock.unlockWrite(stamp);
+    metaTableLock.unlock(stamp);
   }
 
   private int getInactiveMetaTableIndex() {
@@ -181,42 +204,57 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   @Nullable
   public V put(K key, V value) {
     Object encodedKey = createEncodedKey(key);
-    qsbrEnter();
-    LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
-    Long writeLockOnLeafNode = leafNode.acquireWriteLock();
-    try {
-      Optional<V> existingValue = leafNode.lookupAndPutValue(encodedKey, key, value);
-      if (existingValue != null) {
-        return existingValue.orElse(null);
+    while (true) {
+      qsbrEnter();
+      LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
+      Long writeLockOnLeafNode = leafNode.tryWriteLock();
+      if (writeLockOnLeafNode == 0) {
+        continue;
       }
-      qsbrExit();
-      long writeLockOnMetaTable = acquireLockOnMetaTable();
+
       try {
-        long newVersion = version + 1;
+        if (leafNode.getVersion() > qsbrThreadLocalVersions.get().get()) {
+          continue;
+        }
 
-        LeafNode<K, V> newLeafNode =
-            splitLeafNode(getInactiveMetaTable(), leafNode, encodedKey, key, value);
-        addNewLeafNodeToMetaTable(getInactiveMetaTable(), newLeafNode);
+        Optional<V> existingValue = leafNode.lookupAndPutValue(encodedKey, key, value);
+        if (existingValue != null) {
+          return existingValue.orElse(null);
+        }
+        qsbrExit();
+        long writeLockOnMetaTable = tryLockOnMetaTable();
+        if (writeLockOnMetaTable == 0) {
+          continue;
+        }
+        try {
+          long newVersion = version + 1;
 
-        // Increment versions and switch to the updated meta table.
-        leafNode.setVersion(newVersion);
-        newLeafNode.setVersion(newVersion);
-        switchMetaTable(newVersion);
-        leafNode.releaseLock(writeLockOnLeafNode);
-        writeLockOnLeafNode = null;
+          // This new leaf is already locked.
+          LeafNode<K, V> newLeafNode =
+              splitLeafNode(getInactiveMetaTable(), leafNode, encodedKey, key, value);
+          addNewLeafNodeToMetaTable(getInactiveMetaTable(), newLeafNode);
 
-        // Wait until no reader threads on the previously active meta table.
-        qsbrWait(newVersion);
+          // Increment versions and switch to the updated meta table.
+          leafNode.setVersion(newVersion);
+          newLeafNode.setVersion(newVersion);
+          switchMetaTable(newVersion);
+          newLeafNode.releaseLock(newLeafNode.getInitialLockStamp());
+          leafNode.releaseLock(writeLockOnLeafNode);
+          writeLockOnLeafNode = null;
 
-        addNewLeafNodeToMetaTable(getInactiveMetaTable(), newLeafNode);
-        return null;
+          // Wait until no reader threads on the previously active meta table.
+          qsbrWait(newVersion);
+
+          addNewLeafNodeToMetaTable(getInactiveMetaTable(), newLeafNode);
+          return null;
+        } finally {
+          releaseLockOnMetaTable(writeLockOnMetaTable);
+        }
       } finally {
-        releaseLockOnMetaTable(writeLockOnMetaTable);
-      }
-    } finally {
-      qsbrExit();
-      if (writeLockOnLeafNode != null) {
-        leafNode.releaseLock(writeLockOnLeafNode);
+        qsbrExit();
+        if (writeLockOnLeafNode != null) {
+          leafNode.releaseLock(writeLockOnLeafNode);
+        }
       }
     }
   }
@@ -230,48 +268,61 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   @Override
   public boolean delete(K key) {
     Object encodedKey = createEncodedKey(key);
-    qsbrEnter();
-    LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
-    Long writeLockOnLeafNode = leafNode.acquireWriteLock();
-    try {
-      if (!leafNode.delete(encodedKey)) {
-        return false;
+    while (true) {
+      qsbrEnter();
+
+      LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
+      Long writeLockOnLeafNode = leafNode.tryWriteLock();
+      if (writeLockOnLeafNode == 0) {
+        continue;
       }
-      long writeLockOnMetaTable = acquireLockOnMetaTable();
       try {
-        // Merge the nodes on the inactive meta table if needed.
-        Tuple<LeafNode<K, V>, LeafNode<K, V>> mergedLeafNodes = mergeLeafNodesIfNeeded(leafNode);
-        LeafNode<K, V> updatedLeafNode = null;
-        LeafNode<K, V> mergedLeafNode = null;
-        if (mergedLeafNodes != null) {
-          updatedLeafNode = mergedLeafNodes.first;
-          mergedLeafNode = mergedLeafNodes.second;
-          removeMergedLeafNodeFromMetaTable(getInactiveMetaTable(), mergedLeafNode);
+        if (leafNode.getVersion() > qsbrThreadLocalVersions.get().get()) {
+          continue;
         }
-        // Increment versions and switch to the updated meta table.
-        long newVersion = version + 1;
-        leafNode.setVersion(newVersion);
-        if (updatedLeafNode != null && !updatedLeafNode.equals(leafNode)) {
-          updatedLeafNode.setVersion(newVersion);
+        if (leafNode.lookupValue(encodedKey) == null) {
+          return false;
         }
-        switchMetaTable(newVersion);
-        leafNode.releaseLock(writeLockOnLeafNode);
-        writeLockOnLeafNode = null;
-        // Wait until no reader threads on the previously active meta table.
-        qsbrExit();
-        qsbrWait(newVersion);
-        // Remove the merged leaf node from the inactive meta table.
-        if (mergedLeafNode != null) {
-          removeMergedLeafNodeFromMetaTable(getInactiveMetaTable(), mergedLeafNode);
+        long writeLockOnMetaTable = tryLockOnMetaTable();
+        if (writeLockOnMetaTable == 0) {
+          continue;
         }
-        return true;
+        assert leafNode.delete(encodedKey);
+        try {
+          // Merge the nodes on the inactive meta table if needed.
+          Tuple<LeafNode<K, V>, LeafNode<K, V>> mergedLeafNodes = mergeLeafNodesIfNeeded(leafNode);
+          LeafNode<K, V> updatedLeafNode = null;
+          LeafNode<K, V> mergedLeafNode = null;
+          if (mergedLeafNodes != null) {
+            updatedLeafNode = mergedLeafNodes.first;
+            mergedLeafNode = mergedLeafNodes.second;
+            removeMergedLeafNodeFromMetaTable(getInactiveMetaTable(), mergedLeafNode);
+          }
+          // Increment versions and switch to the updated meta table.
+          long newVersion = version + 1;
+          leafNode.setVersion(newVersion);
+          if (updatedLeafNode != null && !updatedLeafNode.equals(leafNode)) {
+            updatedLeafNode.setVersion(newVersion);
+          }
+          switchMetaTable(newVersion);
+          leafNode.releaseLock(writeLockOnLeafNode);
+          writeLockOnLeafNode = null;
+          // Wait until no reader threads on the previously active meta table.
+          qsbrExit();
+          qsbrWait(newVersion);
+          // Remove the merged leaf node from the inactive meta table.
+          if (mergedLeafNode != null) {
+            removeMergedLeafNodeFromMetaTable(getInactiveMetaTable(), mergedLeafNode);
+          }
+          return true;
+        } finally {
+          releaseLockOnMetaTable(writeLockOnMetaTable);
+        }
       } finally {
-        releaseLockOnMetaTable(writeLockOnMetaTable);
-      }
-    } finally {
-      qsbrExit();
-      if (writeLockOnLeafNode != null) {
-        leafNode.releaseLock(writeLockOnLeafNode);
+        qsbrExit();
+        if (writeLockOnLeafNode != null) {
+          leafNode.releaseLock(writeLockOnLeafNode);
+        }
       }
     }
   }
@@ -290,7 +341,10 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
       qsbrEnter();
       try {
         LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
-        long readLockOnLeafNode = leafNode.acquireReadLock();
+        long readLockOnLeafNode = leafNode.tryReadLock();
+        if (readLockOnLeafNode == 0) {
+          continue;
+        }
         try {
           V result = leafNode.lookupValue(encodedKey);
           if (leafNode.getVersion() <= getLocalVersion()) {
@@ -317,6 +371,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     Object encodedEndKey = endKey == null ? null : createEncodedKey(endKey);
     BiFunction<K, V, Boolean> actualFunction = prepareScanFunction(count, function);
 
+    long readLockOnMetaTable = acquireReadLockOnMetaTable();
     try {
       qsbrEnter();
       LeafNode<K, V> leafNode = searchTrieHashTable(encodedStartKey);
@@ -324,8 +379,10 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
         long lockOnLeafNode;
         boolean writeLockOnLeafNode = false;
         while (true) {
-          lockOnLeafNode =
-              writeLockOnLeafNode ? leafNode.acquireWriteLock() : leafNode.acquireReadLock();
+          lockOnLeafNode = writeLockOnLeafNode ? leafNode.tryWriteLock() : leafNode.tryReadLock();
+          if (lockOnLeafNode == 0) {
+            continue;
+          }
           if (writeLockOnLeafNode || leafNode.isKeyRefsSorted()) {
             break;
           }
@@ -333,11 +390,9 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
           writeLockOnLeafNode = true;
         }
         try {
-          if (leafNode.getVersion() > getLocalVersion()) {
-            // FIXME: This break leads to a retry from the beginning, but `actualFunction` can be
-            //        executed multiple times on the same leaf nodes...
-            break;
-          }
+          // A read lock on the meta table is already acquired. So, the version of leaf node doesn't
+          // need to be checked.
+
           leafNode.incSort();
           if (!leafNode.iterateKeyValues(
               encodedStartKey, encodedEndKey, isEndKeyExclusive, actualFunction)) {
@@ -351,6 +406,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
       }
     } finally {
       qsbrExit();
+      releaseLockOnMetaTable(readLockOnMetaTable);
     }
   }
 
@@ -364,5 +420,14 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
       @Nullable LeafNode<K, V> rightNode) {
     return new ConcurrentLeafNode<>(
         encodedKeyType, validAnchorKeyProvider, anchorKey, maxSize, leftNode, rightNode);
+  }
+
+  @Override
+  protected Object provideValidAnchorKeyForSplit(Object anchorKey) {
+    MetaTrieHashTable.NodeMeta existingNodeMeta = getInactiveMetaTable().get(anchorKey);
+    if (existingNodeMeta == null) {
+      return anchorKey;
+    }
+    return null;
   }
 }

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -208,14 +208,13 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
       LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
       Long writeLockOnLeafNode = leafNode.tryWriteLock();
       if (writeLockOnLeafNode == 0) {
+        qsbrExit();
         continue;
       }
-
       try {
         if (leafNode.getVersion() > qsbrThreadLocalVersions.get().get()) {
           continue;
         }
-
         Optional<V> existingValue = leafNode.lookupAndPutValue(encodedKey, key, value);
         if (existingValue != null) {
           return existingValue.orElse(null);
@@ -269,10 +268,10 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     Object encodedKey = createEncodedKey(key);
     while (true) {
       qsbrEnter();
-
       LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
       Long writeLockOnLeafNode = leafNode.tryWriteLock();
       if (writeLockOnLeafNode == 0) {
+        qsbrExit();
         continue;
       }
       try {

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -34,6 +34,7 @@ import org.komamitsu.wormhole4j.MetaTrieHashTable.NodeMetaLeaf;
  * @param <V> the type of values stored in this index
  */
 abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
+  private static final long TRY_LOCK_WAIT_IN_MILLIS = 5;
   // These don't need to be volatile since they are only updated in synchronized blocks.
   private long version;
   private int metaTableIndex;
@@ -163,8 +164,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
 
   private long tryLockOnMetaTable() {
     try {
-      // TODO: Consider no wait.
-      return metaTableLock.tryWriteLock(5, TimeUnit.MILLISECONDS);
+      return metaTableLock.tryWriteLock(TRY_LOCK_WAIT_IN_MILLIS, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new RuntimeException(e);

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -35,8 +35,9 @@ import org.komamitsu.wormhole4j.MetaTrieHashTable.NodeMetaLeaf;
  */
 abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   // These don't need to be volatile since they are only updated in synchronized blocks.
-  private int metaTableIndex;
   private long version;
+  private int metaTableIndex;
+
   private final List<MetaTrieHashTable<K, V>> metaTables;
   private final StampedLock metaTableLock = new StampedLock();
   private final List<AtomicReference<Long>> qsbrVersions;
@@ -70,7 +71,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   }
 
   @Override
-  protected MetaTrieHashTable<K, V> getMetaTable() {
+  protected MetaTrieHashTable<K, V> getActiveMetaTable() {
     return metaTables.get(metaTableIndex);
   }
 
@@ -118,7 +119,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
       throw new IllegalStateException("This thread is not registered yet");
     }
     qsbrThreadLocalVersion.set(version);
-    qsbrThreadLocalMetaTables.set(getMetaTable());
+    qsbrThreadLocalMetaTables.set(getActiveMetaTable());
   }
 
   private void qsbrExit() {
@@ -137,20 +138,24 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   // This method is called by a thread which has acquired the meta table lock.
   // Also, only a few methods takes the synchronized lock which are not frequently called.
   // So method scope synchronized is fine.
-  private synchronized void qsbrWait(long newVersion) {
+  private synchronized void qsbrWait(long newVersion, int threadIndexSkipped) {
     int threadIndex = 0;
     while (true) {
       threadIndex = qsbrThreads.nextSetBit(threadIndex);
       if (threadIndex < 0) {
         break;
       }
+      if (threadIndex == threadIndexSkipped) {
+        threadIndex++;
+        continue;
+      }
       while (true) {
         Long localVersion = qsbrVersions.get(threadIndex).get();
         if (localVersion == null || localVersion == newVersion) {
           break;
         }
-        // Or, Thread.onSpinWait() with Java 9 or later.
-        Thread.yield();
+        // TODO: Call Thread.onSpinWait() here somehow, although Java 8 doesn't have it.
+        //       Thread.yield() affects the performance.
       }
       threadIndex++;
     }
@@ -237,7 +242,8 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
           writeLockOnLeafNode = null;
 
           // Wait until no reader threads on the previously active meta table.
-          qsbrWait(newVersion);
+          qsbrThreadLocalVersions.get().set(newVersion);
+          qsbrWait(newVersion, getQsbrThreadIndex());
 
           addNewLeafNodeToMetaTable(getInactiveMetaTable(), newLeafNode);
           return null;
@@ -302,8 +308,8 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
           leafNode.releaseLock(writeLockOnLeafNode);
           writeLockOnLeafNode = null;
           // Wait until no reader threads on the previously active meta table.
-          qsbrExit();
-          qsbrWait(newVersion);
+          qsbrThreadLocalVersions.get().set(newVersion);
+          qsbrWait(newVersion, getQsbrThreadIndex());
           // Remove the merged leaf node from the inactive meta table.
           if (mergedLeafNode != null) {
             removeMergedLeafNodeFromMetaTable(getInactiveMetaTable(), mergedLeafNode);

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -16,7 +16,9 @@
 
 package org.komamitsu.wormhole4j;
 
-import java.util.Optional;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.StampedLock;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import javax.annotation.Nullable;
@@ -31,7 +33,18 @@ import org.komamitsu.wormhole4j.MetaTrieHashTable.NodeMetaLeaf;
  * @param <V> the type of values stored in this index
  */
 abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
-  private final MetaTrieHashTable<K, V> metaTable;
+  // TODO: Make this configurable.
+  private static final int MAX_THREADS = 512;
+  private int metaTableIndex;
+  private long version;
+  private final List<MetaTrieHashTable<K, V>> metaTables;
+  private final StampedLock metaTableLock = new StampedLock();
+  private final List<AtomicReference<Long>> qsbrVersions;
+  private final BitSet qsbrThreads;
+  private final ThreadLocal<Integer> qsbrThreadLocalIndexes = new ThreadLocal<>();
+  private final ThreadLocal<AtomicReference<Long>> qsbrThreadLocalVersions = new ThreadLocal<>();
+  private final ThreadLocal<MetaTrieHashTable<K, V>> qsbrThreadLocalMetaTables =
+      new ThreadLocal<>();
 
   /**
    * Creates a Wormhole.
@@ -41,14 +54,19 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
    */
   protected ConcurrentWormhole(EncodedKeyType encodedKeyType, int leafNodeSize) {
     super(encodedKeyType, leafNodeSize);
-    this.metaTable = new MetaTrieHashTable<>(encodedKeyType, true);
+    this.metaTables =
+        Arrays.asList(
+            new MetaTrieHashTable<>(encodedKeyType), new MetaTrieHashTable<>(encodedKeyType));
+    this.qsbrVersions = new ArrayList<>(MAX_THREADS);
+    this.qsbrThreads = new BitSet(MAX_THREADS);
     initialize();
   }
 
   private void initialize() {
     Object encodedKey = createEmptyEncodedKey();
     LeafNode<K, V> rootLeafNode = createRootLeafNode(encodedKey);
-    getMetaTable().put(encodedKey, new NodeMetaLeaf<>(encodedKey, rootLeafNode));
+    metaTables.get(0).put(encodedKey, new NodeMetaLeaf<>(encodedKey, rootLeafNode));
+    metaTables.get(1).put(encodedKey, new NodeMetaLeaf<>(encodedKey, rootLeafNode));
   }
 
   protected abstract Object createEncodedKey(K key);
@@ -57,7 +75,80 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
 
   @Override
   protected MetaTrieHashTable<K, V> getMetaTable() {
-    return metaTable;
+    return metaTables.get(metaTableIndex);
+  }
+
+  protected MetaTrieHashTable<K, V> getInactiveMetaTable() {
+    return metaTables.get(metaTableIndex);
+  }
+
+  private int getQsbrThreadIndex() {
+    return qsbrThreadLocalIndexes.get();
+  }
+
+  public synchronized void register() {
+    int availableThreadIndex = qsbrThreads.nextClearBit(0);
+    AtomicReference<Long> versionContainer = new AtomicReference<>();
+    qsbrThreadLocalIndexes.set(availableThreadIndex);
+    qsbrThreadLocalVersions.set(versionContainer);
+    qsbrThreads.set(availableThreadIndex);
+    qsbrVersions.set(availableThreadIndex, versionContainer);
+  }
+
+  public synchronized void unregister() {
+    int qsbrThreadIndex = getQsbrThreadIndex();
+    qsbrVersions.set(qsbrThreadIndex, null);
+    qsbrThreads.clear(qsbrThreadIndex);
+    qsbrThreadLocalMetaTables.remove();
+    qsbrThreadLocalVersions.remove();
+    qsbrThreadLocalIndexes.remove();
+  }
+
+  private void qsbrEnter() {
+    qsbrThreadLocalVersions.get().set(version);
+    qsbrThreadLocalMetaTables.set(getMetaTable());
+  }
+
+  private void qsbrExit() {
+    qsbrThreadLocalMetaTables.remove();
+    qsbrThreadLocalVersions.get().set(null);
+  }
+
+  private long getLocalVersion() {
+    return qsbrThreadLocalVersions.get().get();
+  }
+
+  private synchronized void qsbrWait(long newVersion) {
+    int threadIndex = 0;
+    while (true) {
+      threadIndex = qsbrThreads.nextSetBit(threadIndex);
+      if (threadIndex < 0) {
+        break;
+      }
+      while (true) {
+        Long localVersion = qsbrVersions.get(threadIndex).get();
+        if (localVersion == null || localVersion == newVersion) {
+          break;
+        }
+      }
+    }
+  }
+
+  private long acquireLockOnMetaTable() {
+    return metaTableLock.writeLock();
+  }
+
+  private void releaseLockOnMetaTable(long stamp) {
+    metaTableLock.unlockWrite(stamp);
+  }
+
+  private int getInactiveMetaTableIndex() {
+    return metaTableIndex == 0 ? 1 : 0;
+  }
+
+  private void switchMetaTable(long newVersion) {
+    metaTableIndex = getInactiveMetaTableIndex();
+    version = newVersion;
   }
 
   /**
@@ -72,33 +163,40 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   @Nullable
   public V put(K key, V value) {
     Object encodedKey = createEncodedKey(key);
-    boolean writeLockOnTable = false;
-    while (true) {
-      long tableLock =
-          writeLockOnTable ? metaTable.acquireWriteLock() : metaTable.acquireReadLock();
+    qsbrEnter();
+    LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
+    Long writeLockOnLeafNode = leafNode.acquireWriteLock();
+    try {
+      Optional<V> existingValue = leafNode.lookupAndPutValue(encodedKey, key, value);
+      if (existingValue != null) {
+        return existingValue.orElse(null);
+      }
+      long writeLockOnMetaTable = acquireLockOnMetaTable();
       try {
-        LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
-        long writeLockOnLeafNode = leafNode.acquireWriteLock();
-        try {
-          Optional<V> existingValue = leafNode.lookupAndPutValue(encodedKey, key, value);
-          if (existingValue != null) {
-            return existingValue.orElse(null);
-          }
-
-          // Retry with a write lock when the current lock is a read lock.
-          if (!writeLockOnTable) {
-            writeLockOnTable = true;
-            continue;
-          }
-
-          // Split the node and insert the value to a new leaf node.
-          splitAndInsert(leafNode, encodedKey, key, value);
-          return null;
-        } finally {
-          leafNode.releaseLock(writeLockOnLeafNode);
-        }
+        long newVersion = version + 1;
+        // Split the node and insert the value to a new leaf node on the inactive meta table.
+        LeafNode<K, V> newLeafNode =
+            splitAndInsert(getInactiveMetaTable(), leafNode, encodedKey, key, value);
+        // Increment versions and switch to the updated meta table.
+        leafNode.setVersion(newVersion);
+        newLeafNode.setVersion(newVersion);
+        switchMetaTable(newVersion);
+        leafNode.releaseLock(writeLockOnLeafNode);
+        writeLockOnLeafNode = null;
+        // Wait until no reader threads on the previously active meta table.
+        qsbrExit();
+        qsbrWait(newVersion);
+        // Split the node and insert the value to a new leaf node on the inactive (previously
+        // active) meta table.
+        splitAndInsert(getInactiveMetaTable(), leafNode, encodedKey, key, value);
+        return null;
       } finally {
-        metaTable.releaseLock(tableLock);
+        releaseLockOnMetaTable(writeLockOnMetaTable);
+      }
+    } finally {
+      qsbrExit();
+      if (writeLockOnLeafNode != null) {
+        leafNode.releaseLock(writeLockOnLeafNode);
       }
     }
   }
@@ -112,23 +210,41 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   @Override
   public boolean delete(K key) {
     Object encodedKey = createEncodedKey(key);
-    long tableLock = metaTable.acquireWriteLock();
+    qsbrEnter();
+    LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
+    Long writeLockOnLeafNode = leafNode.acquireWriteLock();
     try {
-      LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
-      long writeLockOnLeafNode = leafNode.acquireWriteLock();
+      if (!leafNode.delete(encodedKey)) {
+        return false;
+      }
+      long writeLockOnMetaTable = acquireLockOnMetaTable();
       try {
-        if (!leafNode.delete(encodedKey)) {
-          return false;
+        // Merge the nodes on the inactive meta table if needed.
+        LeafNode<K, V> updatedLeafNode = mergeIfNeeded(getInactiveMetaTable(), leafNode);
+        // Increment versions and switch to the updated meta table.
+        long newVersion = version + 1;
+        leafNode.setVersion(newVersion);
+        if (updatedLeafNode != null && !updatedLeafNode.equals(leafNode)) {
+          updatedLeafNode.setVersion(newVersion);
         }
-
-        mergeIfNeeded(leafNode);
-      } finally {
+        switchMetaTable(newVersion);
         leafNode.releaseLock(writeLockOnLeafNode);
+        writeLockOnLeafNode = null;
+        // Wait until no reader threads on the previously active meta table.
+        qsbrExit();
+        qsbrWait(newVersion);
+        // Merge the nodes on the inactive (previously active) meta table if needed.
+        mergeIfNeeded(getInactiveMetaTable(), leafNode);
+        return true;
+      } finally {
+        releaseLockOnMetaTable(writeLockOnMetaTable);
       }
     } finally {
-      metaTable.releaseLock(tableLock);
+      qsbrExit();
+      if (writeLockOnLeafNode != null) {
+        leafNode.releaseLock(writeLockOnLeafNode);
+      }
     }
-    return true;
   }
 
   /**
@@ -141,17 +257,22 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   @Nullable
   public V get(K key) {
     Object encodedKey = createEncodedKey(key);
-    long tableLock = metaTable.acquireReadLock();
-    try {
-      LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
-      long readLockOnLeafNode = leafNode.acquireReadLock();
+    while (true) {
+      qsbrEnter();
       try {
-        return leafNode.lookupValue(encodedKey);
+        LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
+        long readLockOnLeafNode = leafNode.acquireReadLock();
+        try {
+          V result = leafNode.lookupValue(encodedKey);
+          if (leafNode.getVersion() <= getLocalVersion()) {
+            return result;
+          }
+        } finally {
+          leafNode.releaseLock(readLockOnLeafNode);
+        }
       } finally {
-        leafNode.releaseLock(readLockOnLeafNode);
+        qsbrExit();
       }
-    } finally {
-      metaTable.releaseLock(tableLock);
     }
   }
 
@@ -167,35 +288,42 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     Object encodedEndKey = endKey == null ? null : createEncodedKey(endKey);
     BiFunction<K, V, Boolean> actualFunction = prepareScanFunction(count, function);
 
-    long tableLock = metaTable.acquireReadLock();
-    try {
-      LeafNode<K, V> leafNode = searchTrieHashTable(encodedStartKey);
-      while (leafNode != null) {
-        long lockOnLeafNode;
-        boolean writeLockOnLeafNode = false;
-        while (true) {
-          lockOnLeafNode =
-              writeLockOnLeafNode ? leafNode.acquireWriteLock() : leafNode.acquireReadLock();
-          if (writeLockOnLeafNode || leafNode.isKeyRefsSorted()) {
-            break;
+    while (true) {
+      qsbrEnter();
+      try {
+        LeafNode<K, V> leafNode = searchTrieHashTable(encodedStartKey);
+        while (leafNode != null) {
+          long lockOnLeafNode;
+          boolean writeLockOnLeafNode = false;
+          while (true) {
+            lockOnLeafNode =
+                writeLockOnLeafNode ? leafNode.acquireWriteLock() : leafNode.acquireReadLock();
+            if (writeLockOnLeafNode || leafNode.isKeyRefsSorted()) {
+              break;
+            }
+            leafNode.releaseLock(lockOnLeafNode);
+            writeLockOnLeafNode = true;
           }
-          leafNode.releaseLock(lockOnLeafNode);
-          writeLockOnLeafNode = true;
-        }
-        try {
-          leafNode.incSort();
-          if (!leafNode.iterateKeyValues(
-              encodedStartKey, encodedEndKey, isEndKeyExclusive, actualFunction)) {
-            return;
+          try {
+            if (leafNode.getVersion() > getLocalVersion()) {
+              // FIXME: This break leads to a retry from the beginning, but `actualFunction` can be
+              // executed multiple times on the same leaf nodes...
+              break;
+            }
+            leafNode.incSort();
+            if (!leafNode.iterateKeyValues(
+                encodedStartKey, encodedEndKey, isEndKeyExclusive, actualFunction)) {
+              return;
+            }
+          } finally {
+            leafNode.releaseLock(lockOnLeafNode);
           }
-        } finally {
-          leafNode.releaseLock(lockOnLeafNode);
+          leafNode = leafNode.getRight();
+          encodedStartKey = null;
         }
-        leafNode = leafNode.getRight();
-        encodedStartKey = null;
+      } finally {
+        qsbrExit();
       }
-    } finally {
-      metaTable.releaseLock(tableLock);
     }
   }
 

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -184,7 +184,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     return metaTableIndex == 0 ? 1 : 0;
   }
 
-  private void switchMetaTable(long newVersion) {
+  private synchronized void switchMetaTable(long newVersion) {
     metaTableIndex = getInactiveMetaTableIndex();
     version = newVersion;
   }

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -70,10 +70,6 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     metaTables.get(1).put(encodedKey, new NodeMetaLeaf<>(encodedKey, rootLeafNode));
   }
 
-  protected abstract Object createEncodedKey(K key);
-
-  protected abstract Object createEmptyEncodedKey();
-
   @Override
   protected MetaTrieHashTable<K, V> getMetaTable() {
     return metaTables.get(metaTableIndex);
@@ -88,7 +84,10 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   }
 
   @Override
-  public synchronized void register() {
+  public synchronized void registerThread() {
+    if (qsbrThreadLocalIndexes.get() != null) {
+      return;
+    }
     int availableThreadIndex = qsbrThreads.nextClearBit(0);
     if (availableThreadIndex >= MAX_THREADS) {
       throw new IllegalStateException("The number of registered threads exceeds " + MAX_THREADS);
@@ -101,18 +100,13 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   }
 
   @Override
-  public synchronized void unregister() {
+  public synchronized void unregisterThread() {
     int qsbrThreadIndex = getQsbrThreadIndex();
     qsbrVersions.set(qsbrThreadIndex, null);
     qsbrThreads.clear(qsbrThreadIndex);
     qsbrThreadLocalMetaTables.remove();
     qsbrThreadLocalVersions.remove();
     qsbrThreadLocalIndexes.remove();
-  }
-
-  @Override
-  public boolean isThreadRegistered() {
-    return qsbrThreadLocalIndexes.get() != null;
   }
 
   private void registerQsbrVersion(int threadIndex, AtomicReference<Long> versionContainer) {
@@ -144,6 +138,9 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     return qsbrThreadLocalVersions.get().get();
   }
 
+  // This method is called by a thread which has acquired the meta table lock.
+  // Also, only a few methods takes the synchronized lock which are not frequently called.
+  // So method scope synchronized is fine.
   private synchronized void qsbrWait(long newVersion) {
     int threadIndex = 0;
     while (true) {

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -34,8 +34,6 @@ import org.komamitsu.wormhole4j.MetaTrieHashTable.NodeMetaLeaf;
  * @param <V> the type of values stored in this index
  */
 abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
-  // TODO: Make this configurable.
-  private static final int MAX_THREADS = 512;
   // These don't need to be volatile since they are only updated in synchronized blocks.
   private int metaTableIndex;
   private long version;
@@ -59,8 +57,8 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     this.metaTables =
         Arrays.asList(
             new MetaTrieHashTable<>(encodedKeyType), new MetaTrieHashTable<>(encodedKeyType));
-    this.qsbrVersions = new ArrayList<>(MAX_THREADS);
-    this.qsbrThreads = new BitSet(MAX_THREADS);
+    this.qsbrVersions = new ArrayList<>();
+    this.qsbrThreads = new BitSet();
     initialize();
   }
 
@@ -90,9 +88,6 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
       return;
     }
     int availableThreadIndex = qsbrThreads.nextClearBit(0);
-    if (availableThreadIndex >= MAX_THREADS) {
-      throw new IllegalStateException("The number of registered threads exceeds " + MAX_THREADS);
-    }
     AtomicReference<Long> versionContainer = new AtomicReference<>();
     qsbrThreadLocalIndexes.set(availableThreadIndex);
     qsbrThreadLocalVersions.set(versionContainer);

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -153,6 +153,8 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
         if (localVersion == null || localVersion == newVersion) {
           break;
         }
+        // Or, Thread.onSpinWait() with Java 9 or later.
+        Thread.yield();
       }
       threadIndex++;
     }

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -17,7 +17,6 @@
 package org.komamitsu.wormhole4j;
 
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.BiFunction;
@@ -34,7 +33,6 @@ import org.komamitsu.wormhole4j.MetaTrieHashTable.NodeMetaLeaf;
  * @param <V> the type of values stored in this index
  */
 abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
-  private static final long TRY_LOCK_WAIT_IN_MILLIS = 5;
   // These don't need to be volatile since they are only updated in synchronized blocks.
   private long version;
   private int metaTableIndex;
@@ -166,12 +164,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
   }
 
   private long tryLockOnMetaTable() {
-    try {
-      return metaTableLock.tryWriteLock(TRY_LOCK_WAIT_IN_MILLIS, TimeUnit.MILLISECONDS);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException(e);
-    }
+    return metaTableLock.tryWriteLock();
   }
 
   private long acquireReadLockOnMetaTable() {

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -189,6 +189,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
       if (existingValue != null) {
         return existingValue.orElse(null);
       }
+      qsbrExit();
       long writeLockOnMetaTable = acquireLockOnMetaTable();
       try {
         long newVersion = version + 1;
@@ -205,7 +206,6 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
         writeLockOnLeafNode = null;
 
         // Wait until no reader threads on the previously active meta table.
-        qsbrExit();
         qsbrWait(newVersion);
 
         addNewLeafNodeToMetaTable(getInactiveMetaTable(), newLeafNode);

--- a/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/ConcurrentWormhole.java
@@ -99,6 +99,9 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
 
   @Override
   public synchronized void unregisterThread() {
+    if (qsbrThreadLocalIndexes.get() == null) {
+      return;
+    }
     int qsbrThreadIndex = getQsbrThreadIndex();
     qsbrVersions.set(qsbrThreadIndex, null);
     qsbrThreads.clear(qsbrThreadIndex);
@@ -120,7 +123,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
       throw new IllegalStateException("This thread is not registered yet");
     }
     qsbrThreadLocalVersion.set(version);
-    qsbrThreadLocalMetaTables.set(getActiveMetaTable());
+    qsbrThreadLocalMetaTables.set(metaTables.get(metaTableIndex));
   }
 
   private void qsbrExit() {
@@ -206,7 +209,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     Object encodedKey = createEncodedKey(key);
     while (true) {
       qsbrEnter();
-      LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
+      LeafNode<K, V> leafNode = searchTrieHashTable(qsbrThreadLocalMetaTables.get(), encodedKey);
       Long writeLockOnLeafNode = leafNode.tryWriteLock();
       if (writeLockOnLeafNode == 0) {
         qsbrExit();
@@ -269,7 +272,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     Object encodedKey = createEncodedKey(key);
     while (true) {
       qsbrEnter();
-      LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
+      LeafNode<K, V> leafNode = searchTrieHashTable(qsbrThreadLocalMetaTables.get(), encodedKey);
       Long writeLockOnLeafNode = leafNode.tryWriteLock();
       if (writeLockOnLeafNode == 0) {
         qsbrExit();
@@ -286,7 +289,8 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
         if (writeLockOnMetaTable == 0) {
           continue;
         }
-        assert leafNode.delete(encodedKey);
+        boolean deleted = leafNode.delete(encodedKey);
+        assert deleted;
         try {
           // Merge the nodes on the inactive meta table if needed.
           Tuple<LeafNode<K, V>, LeafNode<K, V>> mergedLeafNodes = mergeLeafNodesIfNeeded(leafNode);
@@ -341,7 +345,7 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     while (true) {
       qsbrEnter();
       try {
-        LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
+        LeafNode<K, V> leafNode = searchTrieHashTable(qsbrThreadLocalMetaTables.get(), encodedKey);
         long readLockOnLeafNode = leafNode.tryReadLock();
         if (readLockOnLeafNode == 0) {
           continue;
@@ -375,7 +379,8 @@ abstract class ConcurrentWormhole<K, V> extends Wormhole<K, V> {
     long readLockOnMetaTable = acquireReadLockOnMetaTable();
     try {
       qsbrEnter();
-      LeafNode<K, V> leafNode = searchTrieHashTable(encodedStartKey);
+      LeafNode<K, V> leafNode =
+          searchTrieHashTable(qsbrThreadLocalMetaTables.get(), encodedStartKey);
       while (leafNode != null) {
         long lockOnLeafNode;
         boolean writeLockOnLeafNode = false;

--- a/src/main/java/org/komamitsu/wormhole4j/LeafNode.java
+++ b/src/main/java/org/komamitsu/wormhole4j/LeafNode.java
@@ -30,7 +30,7 @@ class LeafNode<K, V> {
   private final EncodedKeyType encodedKeyType;
   final Object anchorKey;
   private final int maxSize;
-  private final Function<Object, Object> validAnchorKeyProvider;
+  private final Function<Object, Object> validAnchorKeyProviderForSplit;
 
   @Nullable private LeafNode<K, V> left;
   @Nullable private LeafNode<K, V> right;
@@ -414,13 +414,13 @@ class LeafNode<K, V> {
   @SuppressWarnings("unchecked")
   LeafNode(
       EncodedKeyType encodedKeyType,
-      Function<Object, Object> validAnchorKeyProvider,
+      Function<Object, Object> validAnchorKeyProviderForSplit,
       Object anchorKey,
       int maxSize,
       @Nullable LeafNode<K, V> left,
       @Nullable LeafNode<K, V> right) {
     this.encodedKeyType = encodedKeyType;
-    this.validAnchorKeyProvider = validAnchorKeyProvider;
+    this.validAnchorKeyProviderForSplit = validAnchorKeyProviderForSplit;
     this.anchorKey = anchorKey;
     this.maxSize = maxSize;
     keyValues = new Object[maxSize * TUPLE_SIZE];
@@ -534,7 +534,7 @@ class LeafNode<K, V> {
     // Copy entries to a new leaf node.
     LeafNode<K, V> newLeafNode =
         createLeafNode(
-            encodedKeyType, validAnchorKeyProvider, newAnchor, maxSize, this, this.right);
+            encodedKeyType, validAnchorKeyProviderForSplit, newAnchor, maxSize, this, this.right);
     List<Integer> keyValueIndexListOfNewLeafNode = new ArrayList<>(currentSize);
     for (int i = startKeyRefIndex; i < currentSize; i++) {
       int keyValueIndex = getKeyValueIndexFromKeyRef(i);
@@ -720,7 +720,7 @@ class LeafNode<K, V> {
       // For anchor-key ≤ node-key, the relationship of `newAnchor` and `k2` always satisfy it.
 
       // Check the anchor key prefix condition.
-      Object validatedAnchorKey = validAnchorKeyProvider.apply(newAnchor);
+      Object validatedAnchorKey = validAnchorKeyProviderForSplit.apply(newAnchor);
       if (validatedAnchorKey == null) {
         continue;
       }
@@ -737,7 +737,19 @@ class LeafNode<K, V> {
     throw new UnsupportedOperationException();
   }
 
+  long tryReadLock() {
+    throw new UnsupportedOperationException();
+  }
+
+  long tryWriteLock() {
+    throw new UnsupportedOperationException();
+  }
+
   void releaseLock(long stamp) {
+    throw new UnsupportedOperationException();
+  }
+
+  long getInitialLockStamp() {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/org/komamitsu/wormhole4j/LeafNode.java
+++ b/src/main/java/org/komamitsu/wormhole4j/LeafNode.java
@@ -585,7 +585,7 @@ class LeafNode<K, V> {
     sortTags();
   }
 
-  Tuple<Object, LeafNode<K, V>> splitToNewLeafNode() {
+  LeafNode<K, V> splitToNewLeafNode() {
     incSort();
 
     Tuple<Integer, Object> found = findSplitPositionAndNewAnchorInLeafNode();
@@ -598,7 +598,7 @@ class LeafNode<K, V> {
 
     removeMovedEntries(keyValuesIndexListOfNewLeafNode);
 
-    return new Tuple<>(newAnchor, newLeafNode);
+    return newLeafNode;
   }
 
   int size() {

--- a/src/main/java/org/komamitsu/wormhole4j/LeafNode.java
+++ b/src/main/java/org/komamitsu/wormhole4j/LeafNode.java
@@ -510,7 +510,7 @@ class LeafNode<K, V> {
     }
   }
 
-  protected LeafNode<K, V> createLeafNode(
+  protected LeafNode<K, V> createLeafNodeForSplit(
       EncodedKeyType encodedKeyType,
       Function<Object, Object> validAnchorKeyProvider,
       Object anchorKey,
@@ -533,7 +533,7 @@ class LeafNode<K, V> {
 
     // Copy entries to a new leaf node.
     LeafNode<K, V> newLeafNode =
-        createLeafNode(
+        createLeafNodeForSplit(
             encodedKeyType, validAnchorKeyProviderForSplit, newAnchor, maxSize, this, this.right);
     List<Integer> keyValueIndexListOfNewLeafNode = new ArrayList<>(currentSize);
     for (int i = startKeyRefIndex; i < currentSize; i++) {

--- a/src/main/java/org/komamitsu/wormhole4j/LeafNode.java
+++ b/src/main/java/org/komamitsu/wormhole4j/LeafNode.java
@@ -741,6 +741,14 @@ class LeafNode<K, V> {
     throw new UnsupportedOperationException();
   }
 
+  long getVersion() {
+    throw new UnsupportedOperationException();
+  }
+
+  void setVersion(long version) {
+    throw new UnsupportedOperationException();
+  }
+
   void validate() {
     Object normalizedAnchorKey = anchorKey;
     Object normalizedRightAnchorKey = null;

--- a/src/main/java/org/komamitsu/wormhole4j/MetaTrieHashTable.java
+++ b/src/main/java/org/komamitsu/wormhole4j/MetaTrieHashTable.java
@@ -242,25 +242,6 @@ class MetaTrieHashTable<K, V> {
     }
   }
 
-  Object removeNodeMetaInternal(Object anchorKey) {
-    NodeMeta removed = table.remove(anchorKey);
-    if (removed == null) {
-      throw new AssertionError(
-          String.format("Node meta internal for anchor key '%s' not found for removal", anchorKey));
-    }
-    if (EncodedKeyUtils.length(encodedKeyType, anchorKey) >= maxAnchorLength) {
-      maxAnchorLength = calcMaxAnchorLength();
-    }
-    if (removed instanceof NodeMetaInternal) {
-      return anchorKey;
-    }
-
-    throw new AssertionError(
-        String.format(
-            "Removed node meta is an unexpected type. Expected: %s, Actual: %s",
-            NodeMetaInternal.class.getName(), removed.getClass().getName()));
-  }
-
   private int calcMaxAnchorLength() {
     int max = 0;
     for (Object key : table.keySet()) {
@@ -274,6 +255,6 @@ class MetaTrieHashTable<K, V> {
 
   @Override
   public String toString() {
-    return "MetaTrieHashTable{" + "table=" + table + '}';
+    return "MetaTrieHashTable{" + "table.size=" + table.size() + '}';
   }
 }

--- a/src/main/java/org/komamitsu/wormhole4j/MetaTrieHashTable.java
+++ b/src/main/java/org/komamitsu/wormhole4j/MetaTrieHashTable.java
@@ -17,7 +17,6 @@
 package org.komamitsu.wormhole4j;
 
 import java.util.*;
-import java.util.concurrent.locks.StampedLock;
 import javax.annotation.Nullable;
 
 class MetaTrieHashTable<K, V> {
@@ -25,34 +24,9 @@ class MetaTrieHashTable<K, V> {
   private int maxAnchorLength;
 
   private final Map<Object, NodeMeta> table = new HashMap<>();
-  private final boolean isConcurrent;
-  private final StampedLock lock = new StampedLock();
 
-  MetaTrieHashTable(EncodedKeyType encodedKeyType, boolean isConcurrent) {
+  MetaTrieHashTable(EncodedKeyType encodedKeyType) {
     this.encodedKeyType = encodedKeyType;
-    this.isConcurrent = isConcurrent;
-  }
-
-  long acquireReadLock() {
-    if (isConcurrent) {
-      return lock.readLock();
-    }
-    throw new UnsupportedOperationException();
-  }
-
-  long acquireWriteLock() {
-    if (isConcurrent) {
-      return lock.writeLock();
-    }
-    throw new UnsupportedOperationException();
-  }
-
-  void releaseLock(long stamp) {
-    if (isConcurrent) {
-      this.lock.unlock(stamp);
-      return;
-    }
-    throw new UnsupportedOperationException();
   }
 
   abstract static class NodeMeta {

--- a/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
@@ -59,6 +59,16 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
   protected abstract Object createEmptyEncodedKey();
 
   @Override
+  public void register() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void unregister() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   protected MetaTrieHashTable<K, V> getMetaTable() {
     return metaTable;
   }

--- a/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
@@ -119,7 +119,10 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
       validateIfNeeded();
       return false;
     }
-    mergeIfNeeded(metaTable, leafNode);
+    Tuple<LeafNode<K, V>, LeafNode<K, V>> mergedLeafNodes = mergeLeafNodesIfNeeded(leafNode);
+    if (mergedLeafNodes != null) {
+      removeMergedLeafNodeFromMetaTable(metaTable, mergedLeafNodes.second);
+    }
     validateIfNeeded();
     return true;
   }

--- a/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
@@ -51,7 +51,7 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
   private void initialize() {
     Object encodedKey = createEmptyEncodedKey();
     LeafNode<K, V> rootLeafNode = createRootLeafNode(encodedKey);
-    getMetaTable().put(encodedKey, new NodeMetaLeaf<>(encodedKey, rootLeafNode));
+    metaTable.put(encodedKey, new NodeMetaLeaf<>(encodedKey, rootLeafNode));
   }
 
   protected abstract Object createEncodedKey(K key);
@@ -65,6 +65,11 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
 
   @Override
   public void unregister() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isThreadRegistered() {
     throw new UnsupportedOperationException();
   }
 
@@ -176,5 +181,14 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
       @Nullable LeafNode<K, V> rightNode) {
     return new LeafNode<>(
         encodedKeyType, validAnchorKeyProvider, anchorKey, maxSize, leftNode, rightNode);
+  }
+
+  @Override
+  protected Object provideValidAnchorKeyForSplit(Object anchorKey) {
+    MetaTrieHashTable.NodeMeta existingNodeMeta = metaTable.get(anchorKey);
+    if (existingNodeMeta == null) {
+      return anchorKey;
+    }
+    return null;
   }
 }

--- a/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
@@ -54,22 +54,13 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
     metaTable.put(encodedKey, new NodeMetaLeaf<>(encodedKey, rootLeafNode));
   }
 
-  protected abstract Object createEncodedKey(K key);
-
-  protected abstract Object createEmptyEncodedKey();
-
   @Override
-  public void register() {
+  public void registerThread() {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void unregister() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public boolean isThreadRegistered() {
+  public void unregisterThread() {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
@@ -88,7 +88,7 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
   @Nullable
   public V put(K key, V value) {
     Object encodedKey = createEncodedKey(key);
-    LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
+    LeafNode<K, V> leafNode = searchTrieHashTable(metaTable, encodedKey);
     Optional<V> existingValue = leafNode.lookupAndPutValue(encodedKey, key, value);
     if (existingValue != null) {
       validateIfNeeded();
@@ -110,7 +110,7 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
   @Override
   public boolean delete(K key) {
     Object encodedKey = createEncodedKey(key);
-    LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
+    LeafNode<K, V> leafNode = searchTrieHashTable(metaTable, encodedKey);
     if (!leafNode.delete(encodedKey)) {
       validateIfNeeded();
       return false;
@@ -133,7 +133,7 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
   @Nullable
   public V get(K key) {
     Object encodedKey = createEncodedKey(key);
-    LeafNode<K, V> leafNode = searchTrieHashTable(encodedKey);
+    LeafNode<K, V> leafNode = searchTrieHashTable(metaTable, encodedKey);
     return leafNode.lookupValue(encodedKey);
   }
 
@@ -148,7 +148,7 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
         startKey == null ? createEmptyEncodedKey() : createEncodedKey(startKey);
     Object encodedEndKey = endKey == null ? null : createEncodedKey(endKey);
     BiFunction<K, V, Boolean> actualFunction = prepareScanFunction(count, function);
-    LeafNode<K, V> leafNode = searchTrieHashTable(encodedStartKey);
+    LeafNode<K, V> leafNode = searchTrieHashTable(metaTable, encodedStartKey);
     while (leafNode != null) {
       leafNode.incSort();
       if (!leafNode.iterateKeyValues(

--- a/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
@@ -99,8 +99,8 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
       return existingValue.orElse(null);
     }
 
-    // Split the node and insert the value to a new leaf node.
-    splitAndInsert(metaTable, leafNode, encodedKey, key, value);
+    LeafNode<K, V> newLeafNode = splitLeafNode(metaTable, leafNode, encodedKey, key, value);
+    addNewLeafNodeToMetaTable(metaTable, newLeafNode);
     validateIfNeeded();
     return null;
   }

--- a/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
@@ -43,7 +43,7 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
    */
   protected SimpleWormhole(EncodedKeyType encodedKeyType, int leafNodeSize, boolean debugMode) {
     super(encodedKeyType, leafNodeSize);
-    this.metaTable = new MetaTrieHashTable<>(encodedKeyType, false);
+    this.metaTable = new MetaTrieHashTable<>(encodedKeyType);
     validator = debugMode ? new WormholeValidator<>(this) : null;
     initialize();
   }
@@ -90,7 +90,7 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
     }
 
     // Split the node and insert the value to a new leaf node.
-    splitAndInsert(leafNode, encodedKey, key, value);
+    splitAndInsert(metaTable, leafNode, encodedKey, key, value);
     validateIfNeeded();
     return null;
   }
@@ -109,7 +109,7 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
       validateIfNeeded();
       return false;
     }
-    mergeIfNeeded(leafNode);
+    mergeIfNeeded(metaTable, leafNode);
     validateIfNeeded();
     return true;
   }

--- a/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
@@ -95,7 +95,7 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
       return existingValue.orElse(null);
     }
 
-    LeafNode<K, V> newLeafNode = splitLeafNode(metaTable, leafNode, encodedKey, key, value);
+    LeafNode<K, V> newLeafNode = splitLeafNode(leafNode, encodedKey, key, value);
     addNewLeafNodeToMetaTable(metaTable, newLeafNode);
     validateIfNeeded();
     return null;

--- a/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/SimpleWormhole.java
@@ -65,7 +65,7 @@ abstract class SimpleWormhole<K, V> extends Wormhole<K, V> {
   }
 
   @Override
-  protected MetaTrieHashTable<K, V> getMetaTable() {
+  protected MetaTrieHashTable<K, V> getActiveMetaTable() {
     return metaTable;
   }
 

--- a/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
@@ -234,13 +234,13 @@ public abstract class Wormhole<K, V> {
     return null;
   }
 
-  LeafNode<K, V> splitAndInsert(
+  LeafNode<K, V> splitLeafNode(
       MetaTrieHashTable<K, V> metaTable,
       LeafNode<K, V> leafNode,
       Object encodedKey,
       K key,
       V value) {
-    LeafNode<K, V> newLeafNode = split(metaTable, leafNode);
+    LeafNode<K, V> newLeafNode = leafNode.splitToNewLeafNode();
     if (EncodedKeyUtils.compare(encodedKeyType, encodedKey, newLeafNode.anchorKey) < 0) {
       leafNode.add(encodedKey, key, value);
     } else {
@@ -249,12 +249,8 @@ public abstract class Wormhole<K, V> {
     return newLeafNode;
   }
 
-  private LeafNode<K, V> split(MetaTrieHashTable<K, V> metaTable, LeafNode<K, V> leafNode) {
-    Tuple<Object, LeafNode<K, V>> newLeafNodeAndAnchor = leafNode.splitToNewLeafNode();
-    Object newAnchor = newLeafNodeAndAnchor.first;
-    LeafNode<K, V> newLeafNode = newLeafNodeAndAnchor.second;
-    metaTable.handleSplitNodes(newAnchor, newLeafNode);
-    return newLeafNode;
+  void addNewLeafNodeToMetaTable(MetaTrieHashTable<K, V> metaTable, LeafNode<K, V> newLeafNode) {
+    metaTable.handleSplitNodes(newLeafNode.anchorKey, newLeafNode);
   }
 
   @Nullable

--- a/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
@@ -63,6 +63,10 @@ public abstract class Wormhole<K, V> {
 
   protected abstract Object createEmptyEncodedKey();
 
+  public abstract void register();
+
+  public abstract void unregister();
+
   /**
    * Inserts or updates a key-value pair.
    *

--- a/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
@@ -164,8 +164,7 @@ public abstract class Wormhole<K, V> {
       @Nullable LeafNode<K, V> leftNode,
       @Nullable LeafNode<K, V> rightNode);
 
-  LeafNode<K, V> searchTrieHashTable(Object encodedKey) {
-    MetaTrieHashTable<K, V> metaTable = getActiveMetaTable();
+  LeafNode<K, V> searchTrieHashTable(MetaTrieHashTable<K, V> metaTable, Object encodedKey) {
     MetaTrieHashTable.NodeMeta nodeMeta =
         metaTable.searchLongestPrefixMatch(encodedKeyType, encodedKey);
     if (nodeMeta instanceof MetaTrieHashTable.NodeMetaLeaf) {
@@ -309,11 +308,6 @@ public abstract class Wormhole<K, V> {
         }
       }
     }
-  }
-
-  @Override
-  public String toString() {
-    return "Wormhole{" + "table=" + getActiveMetaTable() + ", leafNodeSize=" + leafNodeSize + '}';
   }
 
   IntWrapper createEncodedIntKey(Integer key) {

--- a/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
@@ -230,37 +230,48 @@ public abstract class Wormhole<K, V> {
     return null;
   }
 
-  void splitAndInsert(LeafNode<K, V> leafNode, Object encodedKey, K key, V value) {
-    LeafNode<K, V> newLeafNode = split(leafNode);
+  LeafNode<K, V> splitAndInsert(
+      MetaTrieHashTable<K, V> metaTable,
+      LeafNode<K, V> leafNode,
+      Object encodedKey,
+      K key,
+      V value) {
+    LeafNode<K, V> newLeafNode = split(metaTable, leafNode);
     if (EncodedKeyUtils.compare(encodedKeyType, encodedKey, newLeafNode.anchorKey) < 0) {
       leafNode.add(encodedKey, key, value);
     } else {
       newLeafNode.add(encodedKey, key, value);
     }
-  }
-
-  private LeafNode<K, V> split(LeafNode<K, V> leafNode) {
-    Tuple<Object, LeafNode<K, V>> newLeafNodeAndAnchor = leafNode.splitToNewLeafNode();
-    Object newAnchor = newLeafNodeAndAnchor.first;
-    LeafNode<K, V> newLeafNode = newLeafNodeAndAnchor.second;
-    getMetaTable().handleSplitNodes(newAnchor, newLeafNode);
     return newLeafNode;
   }
 
-  void mergeIfNeeded(LeafNode<K, V> leafNode) {
-    if (leafNode.getLeft() != null
-        && leafNode.size() + leafNode.getLeft().size() < leafNodeMergeSize) {
-      merge(leafNode.getLeft(), leafNode);
-    } else if (leafNode.getRight() != null
-        && leafNode.size() + leafNode.getRight().size() < leafNodeMergeSize) {
-      merge(leafNode, leafNode.getRight());
-    }
+  private LeafNode<K, V> split(MetaTrieHashTable<K, V> metaTable, LeafNode<K, V> leafNode) {
+    Tuple<Object, LeafNode<K, V>> newLeafNodeAndAnchor = leafNode.splitToNewLeafNode();
+    Object newAnchor = newLeafNodeAndAnchor.first;
+    LeafNode<K, V> newLeafNode = newLeafNodeAndAnchor.second;
+    metaTable.handleSplitNodes(newAnchor, newLeafNode);
+    return newLeafNode;
   }
 
-  private void merge(LeafNode<K, V> left, LeafNode<K, V> victim) {
+  @Nullable
+  LeafNode<K, V> mergeIfNeeded(MetaTrieHashTable<K, V> metaTable, LeafNode<K, V> leafNode) {
+    // TODO: Check whether this if and else-if are correct.
+    if (leafNode.getLeft() != null
+        && leafNode.size() + leafNode.getLeft().size() < leafNodeMergeSize) {
+      merge(metaTable, leafNode.getLeft(), leafNode);
+      return leafNode.getLeft();
+    } else if (leafNode.getRight() != null
+        && leafNode.size() + leafNode.getRight().size() < leafNodeMergeSize) {
+      merge(metaTable, leafNode, leafNode.getRight());
+      return leafNode;
+    }
+    return null;
+  }
+
+  private void merge(
+      MetaTrieHashTable<K, V> metaTable, LeafNode<K, V> left, LeafNode<K, V> victim) {
     left.merge(victim);
     boolean childNodeRemoved = false;
-    MetaTrieHashTable<K, V> metaTable = getMetaTable();
     for (int prefixlen = EncodedKeyUtils.length(encodedKeyType, victim.anchorKey);
         prefixlen >= 0;
         prefixlen--) {

--- a/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
@@ -39,7 +39,7 @@ public abstract class Wormhole<K, V> {
   private final int leafNodeMergeSize;
   private final Function<Object, Object> validAnchorKeyProvider;
 
-  abstract MetaTrieHashTable<K, V> getMetaTable();
+  abstract MetaTrieHashTable<K, V> getActiveMetaTable();
 
   /**
    * Creates a Wormhole.
@@ -165,7 +165,7 @@ public abstract class Wormhole<K, V> {
       @Nullable LeafNode<K, V> rightNode);
 
   LeafNode<K, V> searchTrieHashTable(Object encodedKey) {
-    MetaTrieHashTable<K, V> metaTable = getMetaTable();
+    MetaTrieHashTable<K, V> metaTable = getActiveMetaTable();
     MetaTrieHashTable.NodeMeta nodeMeta =
         metaTable.searchLongestPrefixMatch(encodedKeyType, encodedKey);
     if (nodeMeta instanceof MetaTrieHashTable.NodeMetaLeaf) {
@@ -313,7 +313,7 @@ public abstract class Wormhole<K, V> {
 
   @Override
   public String toString() {
-    return "Wormhole{" + "table=" + getMetaTable() + ", leafNodeSize=" + leafNodeSize + '}';
+    return "Wormhole{" + "table=" + getActiveMetaTable() + ", leafNodeSize=" + leafNodeSize + '}';
   }
 
   IntWrapper createEncodedIntKey(Integer key) {

--- a/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
@@ -254,23 +254,22 @@ public abstract class Wormhole<K, V> {
   }
 
   @Nullable
-  LeafNode<K, V> mergeIfNeeded(MetaTrieHashTable<K, V> metaTable, LeafNode<K, V> leafNode) {
-    // TODO: Check whether this if and else-if are correct.
+  Tuple<LeafNode<K, V>, LeafNode<K, V>> mergeLeafNodesIfNeeded(LeafNode<K, V> leafNode) {
     if (leafNode.getLeft() != null
         && leafNode.size() + leafNode.getLeft().size() < leafNodeMergeSize) {
-      merge(metaTable, leafNode.getLeft(), leafNode);
-      return leafNode.getLeft();
+      LeafNode<K, V> leftLeafNode = leafNode.getLeft();
+      leftLeafNode.merge(leafNode);
+      return new Tuple<>(leftLeafNode, leafNode);
     } else if (leafNode.getRight() != null
         && leafNode.size() + leafNode.getRight().size() < leafNodeMergeSize) {
-      merge(metaTable, leafNode, leafNode.getRight());
-      return leafNode;
+      LeafNode<K, V> rightLeafNode = leafNode.getRight();
+      leafNode.merge(rightLeafNode);
+      return new Tuple<>(leafNode, rightLeafNode);
     }
     return null;
   }
 
-  private void merge(
-      MetaTrieHashTable<K, V> metaTable, LeafNode<K, V> left, LeafNode<K, V> victim) {
-    left.merge(victim);
+  void removeMergedLeafNodeFromMetaTable(MetaTrieHashTable<K, V> metaTable, LeafNode<K, V> victim) {
     boolean childNodeRemoved = false;
     for (int prefixlen = EncodedKeyUtils.length(encodedKeyType, victim.anchorKey);
         prefixlen >= 0;

--- a/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
@@ -63,11 +63,9 @@ public abstract class Wormhole<K, V> {
 
   protected abstract Object createEmptyEncodedKey();
 
-  public abstract void register();
+  public abstract void registerThread();
 
-  public abstract void unregister();
-
-  public abstract boolean isThreadRegistered();
+  public abstract void unregisterThread();
 
   /**
    * Inserts or updates a key-value pair.

--- a/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
@@ -51,7 +51,7 @@ public abstract class Wormhole<K, V> {
     this.encodedKeyType = encodedKeyType;
     this.leafNodeSize = leafNodeSize;
     this.leafNodeMergeSize = leafNodeSize * 3 / 4;
-    validAnchorKeyProvider = this::provideValidAnchorKey;
+    validAnchorKeyProvider = this::provideValidAnchorKeyForSplit;
   }
 
   LeafNode<K, V> createRootLeafNode(Object encodedKey) {
@@ -66,6 +66,8 @@ public abstract class Wormhole<K, V> {
   public abstract void register();
 
   public abstract void unregister();
+
+  public abstract boolean isThreadRegistered();
 
   /**
    * Inserts or updates a key-value pair.
@@ -226,13 +228,7 @@ public abstract class Wormhole<K, V> {
   }
 
   @Nullable
-  private Object provideValidAnchorKey(Object anchorKey) {
-    MetaTrieHashTable.NodeMeta existingNodeMeta = getMetaTable().get(anchorKey);
-    if (existingNodeMeta == null) {
-      return anchorKey;
-    }
-    return null;
-  }
+  abstract Object provideValidAnchorKeyForSplit(Object anchorKey);
 
   LeafNode<K, V> splitLeafNode(
       MetaTrieHashTable<K, V> metaTable,

--- a/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
+++ b/src/main/java/org/komamitsu/wormhole4j/Wormhole.java
@@ -227,12 +227,7 @@ public abstract class Wormhole<K, V> {
   @Nullable
   abstract Object provideValidAnchorKeyForSplit(Object anchorKey);
 
-  LeafNode<K, V> splitLeafNode(
-      MetaTrieHashTable<K, V> metaTable,
-      LeafNode<K, V> leafNode,
-      Object encodedKey,
-      K key,
-      V value) {
+  LeafNode<K, V> splitLeafNode(LeafNode<K, V> leafNode, Object encodedKey, K key, V value) {
     LeafNode<K, V> newLeafNode = leafNode.splitToNewLeafNode();
     if (EncodedKeyUtils.compare(encodedKeyType, encodedKey, newLeafNode.anchorKey) < 0) {
       leafNode.add(encodedKey, key, value);

--- a/src/main/java/org/komamitsu/wormhole4j/WormholeValidator.java
+++ b/src/main/java/org/komamitsu/wormhole4j/WormholeValidator.java
@@ -72,7 +72,7 @@ class WormholeValidator<K, T> {
   }
 
   private void validateHashTable() {
-    MetaTrieHashTable<K, T> metaTable = wormhole.getMetaTable();
+    MetaTrieHashTable<K, T> metaTable = wormhole.getActiveMetaTable();
     for (Map.Entry<Object, MetaTrieHashTable.NodeMeta> entry : metaTable.entrySetForValidate()) {
       Object key = entry.getKey();
       MetaTrieHashTable.NodeMeta nodeMeta = entry.getValue();
@@ -159,7 +159,7 @@ class WormholeValidator<K, T> {
   }
 
   private void validateInternal() {
-    MetaTrieHashTable<K, T> metaTable = wormhole.getMetaTable();
+    MetaTrieHashTable<K, T> metaTable = wormhole.getActiveMetaTable();
 
     LeafNode<K, T> leftMostLeafNode;
     LeafNode<K, T> rightMostLeafNode;

--- a/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeForIntKeyTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeForIntKeyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Mitsunori Komatsu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.komamitsu.wormhole4j;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+class ConcurrentWormholeForIntKeyTest extends WormholeForIntKeyTest {
+  @BeforeEach
+  void setUp() {
+    wormholeForIntValue =
+        new WormholeBuilder.ForIntKey<Integer>()
+            .setConcurrent(true)
+            .setLeafNodeSize(leafNodeSize)
+            .build();
+    wormholeForIntValue.register();
+
+    wormholeForStrValue =
+        new WormholeBuilder.ForIntKey<String>()
+            .setConcurrent(true)
+            .setLeafNodeSize(leafNodeSize)
+            .build();
+    wormholeForStrValue.register();
+  }
+
+  @AfterEach
+  void tearDown() {
+    wormholeForIntValue.unregister();
+    wormholeForStrValue.unregister();
+  }
+}

--- a/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeForIntKeyTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeForIntKeyTest.java
@@ -27,19 +27,19 @@ class ConcurrentWormholeForIntKeyTest extends WormholeForIntKeyTest {
             .setConcurrent(true)
             .setLeafNodeSize(leafNodeSize)
             .build();
-    wormholeForIntValue.register();
+    wormholeForIntValue.registerThread();
 
     wormholeForStrValue =
         new WormholeBuilder.ForIntKey<String>()
             .setConcurrent(true)
             .setLeafNodeSize(leafNodeSize)
             .build();
-    wormholeForStrValue.register();
+    wormholeForStrValue.registerThread();
   }
 
   @AfterEach
   void tearDown() {
-    wormholeForIntValue.unregister();
-    wormholeForStrValue.unregister();
+    wormholeForIntValue.unregisterThread();
+    wormholeForStrValue.unregisterThread();
   }
 }

--- a/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeForLongKeyTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeForLongKeyTest.java
@@ -27,19 +27,19 @@ class ConcurrentWormholeForLongKeyTest extends WormholeForLongKeyTest {
             .setConcurrent(true)
             .setLeafNodeSize(leafNodeSize)
             .build();
-    wormholeForIntValue.register();
+    wormholeForIntValue.registerThread();
 
     wormholeForStrValue =
         new WormholeBuilder.ForLongKey<String>()
             .setConcurrent(true)
             .setLeafNodeSize(leafNodeSize)
             .build();
-    wormholeForStrValue.register();
+    wormholeForStrValue.registerThread();
   }
 
   @AfterEach
   void tearDown() {
-    wormholeForIntValue.unregister();
-    wormholeForStrValue.unregister();
+    wormholeForIntValue.unregisterThread();
+    wormholeForStrValue.unregisterThread();
   }
 }

--- a/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeForLongKeyTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeForLongKeyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Mitsunori Komatsu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.komamitsu.wormhole4j;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+class ConcurrentWormholeForLongKeyTest extends WormholeForLongKeyTest {
+  @BeforeEach
+  void setUp() {
+    wormholeForIntValue =
+        new WormholeBuilder.ForLongKey<Integer>()
+            .setConcurrent(true)
+            .setLeafNodeSize(leafNodeSize)
+            .build();
+    wormholeForIntValue.register();
+
+    wormholeForStrValue =
+        new WormholeBuilder.ForLongKey<String>()
+            .setConcurrent(true)
+            .setLeafNodeSize(leafNodeSize)
+            .build();
+    wormholeForStrValue.register();
+  }
+
+  @AfterEach
+  void tearDown() {
+    wormholeForIntValue.unregister();
+    wormholeForStrValue.unregister();
+  }
+}

--- a/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeForStringKeyTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeForStringKeyTest.java
@@ -27,19 +27,19 @@ class ConcurrentWormholeForStringKeyTest extends WormholeForStringKeyTest {
             .setConcurrent(true)
             .setLeafNodeSize(leafNodeSize)
             .build();
-    wormholeForIntValue.register();
+    wormholeForIntValue.registerThread();
 
     wormholeForStrValue =
         new WormholeBuilder.ForStringKey<String>()
             .setConcurrent(true)
             .setLeafNodeSize(leafNodeSize)
             .build();
-    wormholeForStrValue.register();
+    wormholeForStrValue.registerThread();
   }
 
   @AfterEach
   void tearDown() {
-    wormholeForIntValue.unregister();
-    wormholeForStrValue.unregister();
+    wormholeForIntValue.unregisterThread();
+    wormholeForStrValue.unregisterThread();
   }
 }

--- a/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeForStringKeyTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeForStringKeyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Mitsunori Komatsu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.komamitsu.wormhole4j;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+class ConcurrentWormholeForStringKeyTest extends WormholeForStringKeyTest {
+  @BeforeEach
+  void setUp() {
+    wormholeForIntValue =
+        new WormholeBuilder.ForStringKey<Integer>()
+            .setConcurrent(true)
+            .setLeafNodeSize(leafNodeSize)
+            .build();
+    wormholeForIntValue.register();
+
+    wormholeForStrValue =
+        new WormholeBuilder.ForStringKey<String>()
+            .setConcurrent(true)
+            .setLeafNodeSize(leafNodeSize)
+            .build();
+    wormholeForStrValue.register();
+  }
+
+  @AfterEach
+  void tearDown() {
+    wormholeForIntValue.unregister();
+    wormholeForStrValue.unregister();
+  }
+}

--- a/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeTest.java
@@ -21,437 +21,513 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.*;
 import java.util.concurrent.*;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 class ConcurrentWormholeTest {
+  private Wormhole<Integer, Integer> wormhole;
+
+  private interface ThrowableSupplier<R, E extends Exception> {
+    R get() throws E;
+  }
+
+  private <R> R withRegisteredWormhole(ThrowableSupplier<R, Exception> task) throws Exception {
+    wormhole.register();
+    try {
+      return task.get();
+    } finally {
+      wormhole.unregister();
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    wormhole =
+        new WormholeBuilder.ForIntKey<Integer>().setConcurrent(true).setLeafNodeSize(4).build();
+  }
+
   @Test
-  void putNewKeysAfterSplit_ShouldReturnNull() {
-    // Arrange
-    Wormhole<Integer, Integer> wormhole =
-        new WormholeBuilder.ForIntKey<Integer>().setConcurrent(true).setLeafNodeSize(4).build();
+  void putNewKeysAfterSplit_ShouldReturnNull() throws Exception {
+    withRegisteredWormhole(
+        () -> {
+          // Act Assert
+          assertThat(wormhole.put(10, 100)).isNull();
+          assertThat(wormhole.put(11, 110)).isNull();
+          assertThat(wormhole.put(9, 90)).isNull();
+          assertThat(wormhole.put(12, 120)).isNull();
+          assertThat(wormhole.put(8, 80)).isNull();
 
-    // Act Assert
-    assertThat(wormhole.put(10, 100)).isNull();
-    assertThat(wormhole.put(11, 110)).isNull();
-    assertThat(wormhole.put(9, 90)).isNull();
-    assertThat(wormhole.put(12, 120)).isNull();
-    assertThat(wormhole.put(8, 80)).isNull();
+          return null;
+        });
   }
 
   @RepeatedTest(10000)
-  void conflict2Puts_ShouldReturnNullAndExistingValue()
-      throws ExecutionException, InterruptedException {
-    // Arrange
-    Wormhole<Integer, Integer> wormhole =
-        new WormholeBuilder.ForIntKey<Integer>().setConcurrent(true).setLeafNodeSize(4).build();
-    ExecutorService executorService = Executors.newFixedThreadPool(2);
-    List<Future<Integer>> futures = new ArrayList<>();
+  void conflict2Puts_ShouldReturnNullAndExistingValue() throws Exception {
+    withRegisteredWormhole(
+        () -> {
+          // Arrange
+          ExecutorService executorService = Executors.newFixedThreadPool(2);
+          List<Future<Integer>> futures = new ArrayList<>();
 
-    try {
-      // Act
-      futures.add(executorService.submit(() -> wormhole.put(1, 10)));
-      futures.add(executorService.submit(() -> wormhole.put(1, 20)));
+          try {
+            // Act
+            futures.add(
+                executorService.submit(() -> withRegisteredWormhole(() -> wormhole.put(1, 10))));
+            futures.add(
+                executorService.submit(() -> withRegisteredWormhole(() -> wormhole.put(1, 20))));
 
-      // Assert
-      List<Integer> resultValues = new ArrayList<>();
-      for (Future<Integer> future : futures) {
-        Integer resultValue = future.get();
-        if (resultValue != null) {
-          resultValues.add(resultValue);
-        }
-      }
-      assertThat(resultValues).hasSize(1);
-      assertThat(resultValues.get(0)).isIn(10, 20);
+            // Assert
+            List<Integer> resultValues = new ArrayList<>();
+            for (Future<Integer> future : futures) {
+              Integer resultValue = future.get();
+              if (resultValue != null) {
+                resultValues.add(resultValue);
+              }
+            }
+            assertThat(resultValues).hasSize(1);
+            assertThat(resultValues.get(0)).isIn(10, 20);
 
-      assertThat(wormhole.get(1)).isIn(10, 20);
-    } finally {
-      executorService.shutdown();
-      if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
-        executorService.shutdownNow();
-      }
-    }
+            assertThat(wormhole.get(1)).isIn(10, 20);
+
+            return null;
+          } finally {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+              executorService.shutdownNow();
+            }
+          }
+        });
   }
 
   @RepeatedTest(10000)
-  void concurrent2PutsAfterSplit_ShouldReturnProperValues_1()
-      throws ExecutionException, InterruptedException {
-    // Arrange
-    Wormhole<Integer, Integer> wormhole =
-        new WormholeBuilder.ForIntKey<Integer>().setConcurrent(true).setLeafNodeSize(4).build();
-    assertThat(wormhole.put(8, 80)).isNull();
-    assertThat(wormhole.put(9, 90)).isNull();
-    assertThat(wormhole.put(10, 100)).isNull();
-    assertThat(wormhole.put(11, 110)).isNull();
+  void concurrent2PutsAfterSplit_ShouldReturnProperValues_1() throws Exception {
+    withRegisteredWormhole(
+        () -> {
+          // Arrange
+          assertThat(wormhole.put(8, 80)).isNull();
+          assertThat(wormhole.put(9, 90)).isNull();
+          assertThat(wormhole.put(10, 100)).isNull();
+          assertThat(wormhole.put(11, 110)).isNull();
 
-    ExecutorService executorService = Executors.newFixedThreadPool(2);
-    List<Future<Integer>> futures = new ArrayList<>();
-    CyclicBarrier barrier = new CyclicBarrier(2);
+          ExecutorService executorService = Executors.newFixedThreadPool(2);
+          List<Future<Integer>> futures = new ArrayList<>();
+          CyclicBarrier barrier = new CyclicBarrier(2);
 
-    try {
-      // Act
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                return wormhole.put(9, 99);
-              }));
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                return wormhole.put(12, 120);
-              }));
+          try {
+            // Act
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              return wormhole.put(9, 99);
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              return wormhole.put(12, 120);
+                            })));
 
-      // Assert
-      List<Integer> resultValues = new ArrayList<>();
-      for (Future<Integer> future : futures) {
-        Integer resultValue = future.get();
-        if (resultValue != null) {
-          resultValues.add(resultValue);
-        }
-      }
-      assertThat(resultValues).hasSize(1);
-      assertThat(resultValues.get(0)).isEqualTo(90);
+            // Assert
+            List<Integer> resultValues = new ArrayList<>();
+            for (Future<Integer> future : futures) {
+              Integer resultValue = future.get();
+              if (resultValue != null) {
+                resultValues.add(resultValue);
+              }
+            }
+            assertThat(resultValues).hasSize(1);
+            assertThat(resultValues.get(0)).isEqualTo(90);
 
-      assertThat(wormhole.get(8)).isEqualTo(80);
-      assertThat(wormhole.get(9)).isEqualTo(99);
-      assertThat(wormhole.get(10)).isEqualTo(100);
-      assertThat(wormhole.get(11)).isEqualTo(110);
-      assertThat(wormhole.get(12)).isEqualTo(120);
-    } finally {
-      executorService.shutdown();
-      if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
-        executorService.shutdownNow();
-      }
-    }
+            assertThat(wormhole.get(8)).isEqualTo(80);
+            assertThat(wormhole.get(9)).isEqualTo(99);
+            assertThat(wormhole.get(10)).isEqualTo(100);
+            assertThat(wormhole.get(11)).isEqualTo(110);
+            assertThat(wormhole.get(12)).isEqualTo(120);
+
+            return null;
+          } finally {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+              executorService.shutdownNow();
+            }
+          }
+        });
   }
 
   @RepeatedTest(10000)
-  void concurrent2PutsAfterSplit_ShouldReturnProperValues_2()
-      throws ExecutionException, InterruptedException {
-    // Arrange
-    Wormhole<Integer, Integer> wormhole =
-        new WormholeBuilder.ForIntKey<Integer>().setConcurrent(true).setLeafNodeSize(4).build();
-    assertThat(wormhole.put(10, 100)).isNull();
-    assertThat(wormhole.put(11, 110)).isNull();
-    assertThat(wormhole.put(12, 120)).isNull();
-    assertThat(wormhole.put(9, 90)).isNull();
+  void concurrent2PutsAfterSplit_ShouldReturnProperValues_2() throws Exception {
+    withRegisteredWormhole(
+        () -> {
+          // Arrange
+          assertThat(wormhole.put(10, 100)).isNull();
+          assertThat(wormhole.put(11, 110)).isNull();
+          assertThat(wormhole.put(12, 120)).isNull();
+          assertThat(wormhole.put(9, 90)).isNull();
 
-    ExecutorService executorService = Executors.newFixedThreadPool(2);
-    List<Future<Integer>> futures = new ArrayList<>();
-    CyclicBarrier barrier = new CyclicBarrier(2);
+          ExecutorService executorService = Executors.newFixedThreadPool(2);
+          List<Future<Integer>> futures = new ArrayList<>();
+          CyclicBarrier barrier = new CyclicBarrier(2);
 
-    try {
-      // Act
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                return wormhole.put(8, 80);
-              }));
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                return wormhole.put(11, 111);
-              }));
+          try {
+            // Act
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              return wormhole.put(8, 80);
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              return wormhole.put(11, 111);
+                            })));
 
-      // Assert
-      List<Integer> resultValues = new ArrayList<>();
-      for (Future<Integer> future : futures) {
-        Integer resultValue = future.get();
-        if (resultValue != null) {
-          resultValues.add(resultValue);
-        }
-      }
-      assertThat(resultValues).hasSize(1);
-      assertThat(resultValues.get(0)).isEqualTo(110);
+            // Assert
+            List<Integer> resultValues = new ArrayList<>();
+            for (Future<Integer> future : futures) {
+              Integer resultValue = future.get();
+              if (resultValue != null) {
+                resultValues.add(resultValue);
+              }
+            }
+            assertThat(resultValues).hasSize(1);
+            assertThat(resultValues.get(0)).isEqualTo(110);
 
-      assertThat(wormhole.get(8)).isEqualTo(80);
-      assertThat(wormhole.get(9)).isEqualTo(90);
-      assertThat(wormhole.get(10)).isEqualTo(100);
-      assertThat(wormhole.get(11)).isEqualTo(111);
-      assertThat(wormhole.get(12)).isEqualTo(120);
-    } finally {
-      executorService.shutdown();
-      if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
-        executorService.shutdownNow();
-      }
-    }
+            assertThat(wormhole.get(8)).isEqualTo(80);
+            assertThat(wormhole.get(9)).isEqualTo(90);
+            assertThat(wormhole.get(10)).isEqualTo(100);
+            assertThat(wormhole.get(11)).isEqualTo(111);
+            assertThat(wormhole.get(12)).isEqualTo(120);
+
+            return null;
+          } finally {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+              executorService.shutdownNow();
+            }
+          }
+        });
   }
 
   @RepeatedTest(10000)
-  void concurrent3PutsAfterSplit_ShouldReturnProperValues_simplified()
-      throws ExecutionException, InterruptedException {
-    // Arrange
-    Wormhole<Integer, Integer> wormhole =
-        new WormholeBuilder.ForIntKey<Integer>().setConcurrent(true).setLeafNodeSize(4).build();
-    assertThat(wormhole.put(10, 100)).isNull();
-    assertThat(wormhole.put(11, 110)).isNull();
-    assertThat(wormhole.put(9, 90)).isNull();
-    assertThat(wormhole.put(7, 70)).isNull();
-    assertThat(wormhole.put(14, 140)).isNull();
+  void concurrent3PutsAfterSplit_ShouldReturnProperValues_simplified() throws Exception {
+    withRegisteredWormhole(
+        () -> {
+          // Arrange
+          assertThat(wormhole.put(10, 100)).isNull();
+          assertThat(wormhole.put(11, 110)).isNull();
+          assertThat(wormhole.put(9, 90)).isNull();
+          assertThat(wormhole.put(7, 70)).isNull();
+          assertThat(wormhole.put(14, 140)).isNull();
 
-    ExecutorService executorService = Executors.newFixedThreadPool(3);
-    List<Future<List<Integer>>> futures = new ArrayList<>();
-    CyclicBarrier barrier = new CyclicBarrier(3);
+          ExecutorService executorService = Executors.newFixedThreadPool(3);
+          List<Future<List<Integer>>> futures = new ArrayList<>();
+          CyclicBarrier barrier = new CyclicBarrier(3);
 
-    try {
-      // Act
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                List<Integer> existingValues = new ArrayList<>();
-                existingValues.add(wormhole.put(12, 120));
-                return existingValues;
-              }));
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                List<Integer> existingValues = new ArrayList<>();
-                existingValues.add(wormhole.put(13, 130));
-                return existingValues;
-              }));
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                List<Integer> existingValues = new ArrayList<>();
-                existingValues.add(wormhole.put(15, 150));
-                return existingValues;
-              }));
+          try {
+            // Act
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              List<Integer> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.put(12, 120));
+                              return existingValues;
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              List<Integer> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.put(13, 130));
+                              return existingValues;
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              List<Integer> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.put(15, 150));
+                              return existingValues;
+                            })));
 
-      // Assert
-      List<Integer> resultValues = new ArrayList<>();
-      for (Future<List<Integer>> future : futures) {
-        List<Integer> result = future.get().stream().filter(Objects::nonNull).collect(toList());
-        resultValues.addAll(result);
-      }
-      assertThat(resultValues).hasSize(0);
+            // Assert
+            List<Integer> resultValues = new ArrayList<>();
+            for (Future<List<Integer>> future : futures) {
+              List<Integer> result =
+                  future.get().stream().filter(Objects::nonNull).collect(toList());
+              resultValues.addAll(result);
+            }
+            assertThat(resultValues).hasSize(0);
 
-      assertThat(wormhole.get(7)).isEqualTo(70);
-      assertThat(wormhole.get(9)).isEqualTo(90);
-      assertThat(wormhole.get(10)).isEqualTo(100);
-      assertThat(wormhole.get(11)).isEqualTo(110);
-      assertThat(wormhole.get(12)).isEqualTo(120);
-      assertThat(wormhole.get(13)).isEqualTo(130);
-      assertThat(wormhole.get(14)).isEqualTo(140);
-      assertThat(wormhole.get(15)).isEqualTo(150);
-    } finally {
-      executorService.shutdown();
-      if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
-        executorService.shutdownNow();
-      }
-    }
+            assertThat(wormhole.get(7)).isEqualTo(70);
+            assertThat(wormhole.get(9)).isEqualTo(90);
+            assertThat(wormhole.get(10)).isEqualTo(100);
+            assertThat(wormhole.get(11)).isEqualTo(110);
+            assertThat(wormhole.get(12)).isEqualTo(120);
+            assertThat(wormhole.get(13)).isEqualTo(130);
+            assertThat(wormhole.get(14)).isEqualTo(140);
+            assertThat(wormhole.get(15)).isEqualTo(150);
+
+            return null;
+          } finally {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+              executorService.shutdownNow();
+            }
+          }
+        });
   }
 
   @RepeatedTest(10000)
-  void concurrent3PutsAfterSplit_ShouldReturnProperValues_1()
-      throws ExecutionException, InterruptedException {
-    // Arrange
-    Wormhole<Integer, Integer> wormhole =
-        new WormholeBuilder.ForIntKey<Integer>().setConcurrent(true).setLeafNodeSize(4).build();
-    assertThat(wormhole.put(10, 100)).isNull();
-    assertThat(wormhole.put(11, 110)).isNull();
-    assertThat(wormhole.put(9, 90)).isNull();
+  void concurrent3PutsAfterSplit_ShouldReturnProperValues_1() throws Exception {
+    withRegisteredWormhole(
+        () -> {
+          // Arrange
+          assertThat(wormhole.put(10, 100)).isNull();
+          assertThat(wormhole.put(11, 110)).isNull();
+          assertThat(wormhole.put(9, 90)).isNull();
 
-    ExecutorService executorService = Executors.newFixedThreadPool(3);
-    List<Future<List<Integer>>> futures = new ArrayList<>();
-    CyclicBarrier barrier = new CyclicBarrier(3);
+          ExecutorService executorService = Executors.newFixedThreadPool(3);
+          List<Future<List<Integer>>> futures = new ArrayList<>();
+          CyclicBarrier barrier = new CyclicBarrier(3);
 
-    try {
-      // Act
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                List<Integer> existingValues = new ArrayList<>();
-                existingValues.add(wormhole.put(7, 70));
-                existingValues.add(wormhole.put(12, 120));
-                return existingValues;
-              }));
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                List<Integer> existingValues = new ArrayList<>();
-                existingValues.add(wormhole.put(13, 130));
-                return existingValues;
-              }));
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                List<Integer> existingValues = new ArrayList<>();
-                existingValues.add(wormhole.put(14, 140));
-                existingValues.add(wormhole.put(15, 150));
-                return existingValues;
-              }));
+          try {
+            // Act
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              List<Integer> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.put(7, 70));
+                              existingValues.add(wormhole.put(12, 120));
+                              return existingValues;
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              List<Integer> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.put(13, 130));
+                              return existingValues;
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              List<Integer> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.put(14, 140));
+                              existingValues.add(wormhole.put(15, 150));
+                              return existingValues;
+                            })));
 
-      // Assert
-      List<Integer> resultValues = new ArrayList<>();
-      for (Future<List<Integer>> future : futures) {
-        List<Integer> result = future.get().stream().filter(Objects::nonNull).collect(toList());
-        resultValues.addAll(result);
-      }
-      assertThat(resultValues).hasSize(0);
+            // Assert
+            List<Integer> resultValues = new ArrayList<>();
+            for (Future<List<Integer>> future : futures) {
+              List<Integer> result =
+                  future.get().stream().filter(Objects::nonNull).collect(toList());
+              resultValues.addAll(result);
+            }
+            assertThat(resultValues).hasSize(0);
 
-      assertThat(wormhole.get(7)).isEqualTo(70);
-      assertThat(wormhole.get(9)).isEqualTo(90);
-      assertThat(wormhole.get(10)).isEqualTo(100);
-      assertThat(wormhole.get(11)).isEqualTo(110);
-      assertThat(wormhole.get(12)).isEqualTo(120);
-      assertThat(wormhole.get(13)).isEqualTo(130);
-      assertThat(wormhole.get(14)).isEqualTo(140);
-      assertThat(wormhole.get(15)).isEqualTo(150);
-    } finally {
-      executorService.shutdown();
-      if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
-        executorService.shutdownNow();
-      }
-    }
+            assertThat(wormhole.get(7)).isEqualTo(70);
+            assertThat(wormhole.get(9)).isEqualTo(90);
+            assertThat(wormhole.get(10)).isEqualTo(100);
+            assertThat(wormhole.get(11)).isEqualTo(110);
+            assertThat(wormhole.get(12)).isEqualTo(120);
+            assertThat(wormhole.get(13)).isEqualTo(130);
+            assertThat(wormhole.get(14)).isEqualTo(140);
+            assertThat(wormhole.get(15)).isEqualTo(150);
+
+            return null;
+          } finally {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+              executorService.shutdownNow();
+            }
+          }
+        });
   }
 
   @RepeatedTest(10000)
-  void concurrent3PutsAfterSplit_ShouldReturnProperValues_2()
-      throws ExecutionException, InterruptedException {
-    // Arrange
-    Wormhole<Integer, Integer> wormhole =
-        new WormholeBuilder.ForIntKey<Integer>().setConcurrent(true).setLeafNodeSize(4).build();
-    assertThat(wormhole.put(11, 110)).isNull();
-    assertThat(wormhole.put(9, 90)).isNull();
-    assertThat(wormhole.put(12, 120)).isNull();
-    assertThat(wormhole.put(8, 80)).isNull();
+  void concurrent3PutsAfterSplit_ShouldReturnProperValues_2() throws Exception {
+    withRegisteredWormhole(
+        () -> {
+          // Arrange
+          assertThat(wormhole.put(11, 110)).isNull();
+          assertThat(wormhole.put(9, 90)).isNull();
+          assertThat(wormhole.put(12, 120)).isNull();
+          assertThat(wormhole.put(8, 80)).isNull();
 
-    ExecutorService executorService = Executors.newFixedThreadPool(3);
-    List<Future<List<Integer>>> futures = new ArrayList<>();
-    CyclicBarrier barrier = new CyclicBarrier(3);
+          ExecutorService executorService = Executors.newFixedThreadPool(3);
+          List<Future<List<Integer>>> futures = new ArrayList<>();
+          CyclicBarrier barrier = new CyclicBarrier(3);
 
-    try {
-      // Act
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                List<Integer> existingValues = new ArrayList<>();
-                existingValues.add(wormhole.put(10, 100));
-                return existingValues;
-              }));
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                List<Integer> existingValues = new ArrayList<>();
-                existingValues.add(wormhole.put(13, 130));
-                return existingValues;
-              }));
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                List<Integer> existingValues = new ArrayList<>();
-                existingValues.add(wormhole.put(15, 150));
-                return existingValues;
-              }));
+          try {
+            // Act
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              List<Integer> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.put(10, 100));
+                              return existingValues;
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              List<Integer> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.put(13, 130));
+                              return existingValues;
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              List<Integer> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.put(15, 150));
+                              return existingValues;
+                            })));
 
-      // Assert
-      List<Integer> resultValues = new ArrayList<>();
-      for (Future<List<Integer>> future : futures) {
-        List<Integer> result = future.get().stream().filter(Objects::nonNull).collect(toList());
-        resultValues.addAll(result);
-      }
-      assertThat(resultValues).hasSize(0);
+            // Assert
+            List<Integer> resultValues = new ArrayList<>();
+            for (Future<List<Integer>> future : futures) {
+              List<Integer> result =
+                  future.get().stream().filter(Objects::nonNull).collect(toList());
+              resultValues.addAll(result);
+            }
+            assertThat(resultValues).hasSize(0);
 
-      assertThat(wormhole.get(8)).isEqualTo(80);
-      assertThat(wormhole.get(9)).isEqualTo(90);
-      assertThat(wormhole.get(10)).isEqualTo(100);
-      assertThat(wormhole.get(11)).isEqualTo(110);
-      assertThat(wormhole.get(12)).isEqualTo(120);
-      assertThat(wormhole.get(13)).isEqualTo(130);
-      assertThat(wormhole.get(15)).isEqualTo(150);
-    } finally {
-      executorService.shutdown();
-      if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
-        executorService.shutdownNow();
-      }
-    }
+            assertThat(wormhole.get(8)).isEqualTo(80);
+            assertThat(wormhole.get(9)).isEqualTo(90);
+            assertThat(wormhole.get(10)).isEqualTo(100);
+            assertThat(wormhole.get(11)).isEqualTo(110);
+            assertThat(wormhole.get(12)).isEqualTo(120);
+            assertThat(wormhole.get(13)).isEqualTo(130);
+            assertThat(wormhole.get(15)).isEqualTo(150);
+
+            return null;
+          } finally {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+              executorService.shutdownNow();
+            }
+          }
+        });
   }
 
   @RepeatedTest(10000)
-  void concurrent3PutsAfterSplit_ShouldReturnProperValues_3()
-      throws ExecutionException, InterruptedException, TimeoutException {
-    // Arrange
-    Wormhole<Integer, Integer> wormhole =
-        new WormholeBuilder.ForIntKey<Integer>().setConcurrent(true).setLeafNodeSize(4).build();
-    assertThat(wormhole.put(11, 110)).isNull();
-    assertThat(wormhole.put(10, 100)).isNull();
-    assertThat(wormhole.put(8, 80)).isNull();
-    assertThat(wormhole.put(6, 60)).isNull();
-    assertThat(wormhole.put(9, 90)).isNull();
-    assertThat(wormhole.put(15, 150)).isNull();
-    assertThat(wormhole.put(16, 160)).isNull();
+  void concurrent3PutsAfterSplit_ShouldReturnProperValues_3() throws Exception {
+    withRegisteredWormhole(
+        () -> {
+          // Arrange
+          assertThat(wormhole.put(11, 110)).isNull();
+          assertThat(wormhole.put(10, 100)).isNull();
+          assertThat(wormhole.put(8, 80)).isNull();
+          assertThat(wormhole.put(6, 60)).isNull();
+          assertThat(wormhole.put(9, 90)).isNull();
+          assertThat(wormhole.put(15, 150)).isNull();
+          assertThat(wormhole.put(16, 160)).isNull();
 
-    assertThat(wormhole.put(7, 70)).isNull();
+          assertThat(wormhole.put(7, 70)).isNull();
 
-    ExecutorService executorService = Executors.newFixedThreadPool(3);
-    List<Future<List<Integer>>> futures = new ArrayList<>();
-    CyclicBarrier barrier = new CyclicBarrier(3);
+          ExecutorService executorService = Executors.newFixedThreadPool(3);
+          List<Future<List<Integer>>> futures = new ArrayList<>();
+          CyclicBarrier barrier = new CyclicBarrier(3);
 
-    try {
-      // Act
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                List<Integer> existingValues = new ArrayList<>();
-                existingValues.add(wormhole.put(5, 50));
-                return existingValues;
-              }));
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                List<Integer> existingValues = new ArrayList<>();
-                Thread.sleep(0, 50);
-                wormhole.get(4);
-                return existingValues;
-              }));
-      futures.add(
-          executorService.submit(
-              () -> {
-                barrier.await();
-                List<Integer> existingValues = new ArrayList<>();
-                existingValues.add(wormhole.put(17, 170));
-                return existingValues;
-              }));
+          try {
+            // Act
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              List<Integer> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.put(5, 50));
+                              return existingValues;
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              List<Integer> existingValues = new ArrayList<>();
+                              Thread.sleep(0, 50);
+                              wormhole.get(4);
+                              return existingValues;
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              List<Integer> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.put(17, 170));
+                              return existingValues;
+                            })));
 
-      // Assert
-      List<Integer> resultValues = new ArrayList<>();
-      for (Future<List<Integer>> future : futures) {
-        List<Integer> result =
-            future.get(10, TimeUnit.SECONDS).stream().filter(Objects::nonNull).collect(toList());
-        resultValues.addAll(result);
-      }
-      assertThat(resultValues).hasSize(0);
+            // Assert
+            List<Integer> resultValues = new ArrayList<>();
+            for (Future<List<Integer>> future : futures) {
+              List<Integer> result =
+                  future.get(10, TimeUnit.SECONDS).stream()
+                      .filter(Objects::nonNull)
+                      .collect(toList());
+              resultValues.addAll(result);
+            }
+            assertThat(resultValues).hasSize(0);
 
-      assertThat(wormhole.get(5)).isEqualTo(50);
-      assertThat(wormhole.get(6)).isEqualTo(60);
-      assertThat(wormhole.get(7)).isEqualTo(70);
-      assertThat(wormhole.get(8)).isEqualTo(80);
-      assertThat(wormhole.get(9)).isEqualTo(90);
-      assertThat(wormhole.get(10)).isEqualTo(100);
-      assertThat(wormhole.get(11)).isEqualTo(110);
-      assertThat(wormhole.get(15)).isEqualTo(150);
-      assertThat(wormhole.get(16)).isEqualTo(160);
-      assertThat(wormhole.get(17)).isEqualTo(170);
-    } finally {
-      executorService.shutdown();
-      if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
-        executorService.shutdownNow();
-      }
-    }
+            assertThat(wormhole.get(5)).isEqualTo(50);
+            assertThat(wormhole.get(6)).isEqualTo(60);
+            assertThat(wormhole.get(7)).isEqualTo(70);
+            assertThat(wormhole.get(8)).isEqualTo(80);
+            assertThat(wormhole.get(9)).isEqualTo(90);
+            assertThat(wormhole.get(10)).isEqualTo(100);
+            assertThat(wormhole.get(11)).isEqualTo(110);
+            assertThat(wormhole.get(15)).isEqualTo(150);
+            assertThat(wormhole.get(16)).isEqualTo(160);
+            assertThat(wormhole.get(17)).isEqualTo(170);
+
+            return null;
+          } finally {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+              executorService.shutdownNow();
+            }
+          }
+        });
   }
 }

--- a/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeTest.java
@@ -33,11 +33,11 @@ class ConcurrentWormholeTest {
   }
 
   private <R> R withRegisteredWormhole(ThrowableSupplier<R, Exception> task) throws Exception {
-    wormhole.register();
+    wormhole.registerThread();
     try {
       return task.get();
     } finally {
-      wormhole.unregister();
+      wormhole.unregisterThread();
     }
   }
 

--- a/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeTest.java
@@ -221,6 +221,69 @@ class ConcurrentWormholeTest {
   }
 
   @RepeatedTest(10000)
+  void concurrent2PutsAfterSplit_ShouldReturnProperValues_3() throws Exception {
+    withRegisteredWormhole(
+        () -> {
+          // Arrange
+          assertThat(wormhole.put(10, 100)).isNull();
+          assertThat(wormhole.put(11, 110)).isNull();
+          assertThat(wormhole.put(13, 130)).isNull();
+          assertThat(wormhole.put(14, 140)).isNull();
+          assertThat(wormhole.put(7, 70)).isNull();
+          assertThat(wormhole.put(8, 80)).isNull();
+
+          ExecutorService executorService = Executors.newFixedThreadPool(2);
+          List<Future<Integer>> futures = new ArrayList<>();
+          CyclicBarrier barrier = new CyclicBarrier(2);
+
+          try {
+            // Act
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              return wormhole.put(6, 60);
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              return wormhole.put(7, 71);
+                            })));
+
+            // Assert
+            List<Integer> resultValues = new ArrayList<>();
+            for (Future<Integer> future : futures) {
+              Integer resultValue = future.get();
+              if (resultValue != null) {
+                resultValues.add(resultValue);
+              }
+            }
+            assertThat(resultValues).hasSize(1);
+            assertThat(resultValues.get(0)).isEqualTo(70);
+
+            assertThat(wormhole.get(7)).isEqualTo(71);
+            assertThat(wormhole.get(8)).isEqualTo(80);
+            assertThat(wormhole.get(10)).isEqualTo(100);
+            assertThat(wormhole.get(11)).isEqualTo(110);
+            assertThat(wormhole.get(13)).isEqualTo(130);
+            assertThat(wormhole.get(14)).isEqualTo(140);
+
+            return null;
+          } finally {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+              executorService.shutdownNow();
+            }
+          }
+        });
+  }
+
+  @RepeatedTest(10000)
   void concurrent3PutsAfterSplit_ShouldReturnProperValues_simplified() throws Exception {
     withRegisteredWormhole(
         () -> {
@@ -520,6 +583,211 @@ class ConcurrentWormholeTest {
             assertThat(wormhole.get(15)).isEqualTo(150);
             assertThat(wormhole.get(16)).isEqualTo(160);
             assertThat(wormhole.get(17)).isEqualTo(170);
+
+            return null;
+          } finally {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+              executorService.shutdownNow();
+            }
+          }
+        });
+  }
+
+  @RepeatedTest(10000)
+  void concurrent3PutsAfterSplit_ShouldReturnProperValues_4() throws Exception {
+    withRegisteredWormhole(
+        () -> {
+          // Arrange
+          assertThat(wormhole.put(10, 100)).isNull();
+          assertThat(wormhole.put(13, 130)).isNull();
+
+          ExecutorService executorService = Executors.newFixedThreadPool(3);
+          List<Future<List<Integer>>> futures = new ArrayList<>();
+          CyclicBarrier barrier1 = new CyclicBarrier(3);
+          CyclicBarrier barrier2 = new CyclicBarrier(2);
+
+          try {
+            // Act
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              List<Integer> existingValues = new ArrayList<>();
+                              barrier1.await();
+                              existingValues.add(wormhole.put(11, 110));
+                              barrier2.await();
+                              existingValues.add(wormhole.put(8, 80));
+                              return existingValues;
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier1.await();
+                              List<Integer> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.put(12, 120));
+                              barrier2.await();
+                              existingValues.add(wormhole.put(7, 70));
+                              return existingValues;
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier1.await();
+                              List<Integer> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.put(6, 60));
+                              return existingValues;
+                            })));
+
+            // Assert
+            List<Integer> resultValues = new ArrayList<>();
+            for (Future<List<Integer>> future : futures) {
+              List<Integer> result =
+                  future.get(10, TimeUnit.SECONDS).stream()
+                      .filter(Objects::nonNull)
+                      .collect(toList());
+              resultValues.addAll(result);
+            }
+            assertThat(resultValues).hasSize(0);
+
+            assertThat(wormhole.get(6)).isEqualTo(60);
+            assertThat(wormhole.get(7)).isEqualTo(70);
+            assertThat(wormhole.get(8)).isEqualTo(80);
+            assertThat(wormhole.get(10)).isEqualTo(100);
+            assertThat(wormhole.get(11)).isEqualTo(110);
+            assertThat(wormhole.get(12)).isEqualTo(120);
+            assertThat(wormhole.get(13)).isEqualTo(130);
+
+            return null;
+          } finally {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+              executorService.shutdownNow();
+            }
+          }
+        });
+  }
+
+  @RepeatedTest(10000)
+  void concurrent2Deletes_ShouldReturnProperValues() throws Exception {
+    withRegisteredWormhole(
+        () -> {
+          // Arrange
+          assertThat(wormhole.put(9, 90)).isNull();
+          assertThat(wormhole.put(10, 100)).isNull();
+
+          ExecutorService executorService = Executors.newFixedThreadPool(3);
+          List<Future<List<Boolean>>> futures = new ArrayList<>();
+          CyclicBarrier barrier = new CyclicBarrier(2);
+
+          try {
+            // Act
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              List<Boolean> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.delete(9));
+                              return existingValues;
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              List<Boolean> existingValues = new ArrayList<>();
+                              existingValues.add(wormhole.delete(10));
+                              return existingValues;
+                            })));
+
+            // Assert
+            List<Boolean> resultValues = new ArrayList<>();
+            for (Future<List<Boolean>> future : futures) {
+              List<Boolean> result =
+                  future.get().stream().filter(Objects::nonNull).collect(toList());
+              resultValues.addAll(result);
+            }
+            assertThat(resultValues).hasSize(2);
+            assertThat(resultValues.get(0)).isTrue();
+            assertThat(resultValues.get(1)).isTrue();
+
+            assertThat(wormhole.get(9)).isNull();
+            assertThat(wormhole.get(10)).isNull();
+
+            return null;
+          } finally {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+              executorService.shutdownNow();
+            }
+          }
+        });
+  }
+
+  @RepeatedTest(10000)
+  void concurrentPutAndDelete_ShouldReturnProperValues() throws Exception {
+    withRegisteredWormhole(
+        () -> {
+          // Arrange
+          assertThat(wormhole.put(8, 80)).isNull();
+          assertThat(wormhole.put(10, 100)).isNull();
+          assertThat(wormhole.put(12, 120)).isNull();
+          assertThat(wormhole.put(13, 130)).isNull();
+
+          ExecutorService executorService = Executors.newFixedThreadPool(3);
+          List<Future<List<Boolean>>> deleteFutures = new ArrayList<>();
+          List<Future<List<Integer>>> putFutures = new ArrayList<>();
+          CyclicBarrier barrier = new CyclicBarrier(2);
+
+          try {
+            // Act
+            putFutures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              return Arrays.asList(wormhole.put(7, 70));
+                            })));
+            deleteFutures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier.await();
+                              return Arrays.asList(wormhole.delete(12));
+                            })));
+
+            // Assert
+            List<Integer> resultPutValues = new ArrayList<>();
+            for (Future<List<Integer>> future : putFutures) {
+              List<Integer> result =
+                  future.get().stream().filter(Objects::nonNull).collect(toList());
+              resultPutValues.addAll(result);
+            }
+            List<Boolean> resultDeleteValues = new ArrayList<>();
+            for (Future<List<Boolean>> future : deleteFutures) {
+              List<Boolean> result =
+                  future.get().stream().filter(Objects::nonNull).collect(toList());
+              resultDeleteValues.addAll(result);
+            }
+            assertThat(resultPutValues).hasSize(0);
+            assertThat(resultDeleteValues).hasSize(1);
+            assertThat(resultDeleteValues.get(0)).isTrue();
+
+            assertThat(wormhole.get(7)).isEqualTo(70);
+            assertThat(wormhole.get(8)).isEqualTo(80);
+            assertThat(wormhole.get(10)).isEqualTo(100);
+            assertThat(wormhole.get(12)).isNull();
+            assertThat(wormhole.get(13)).isEqualTo(130);
 
             return null;
           } finally {

--- a/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/ConcurrentWormholeTest.java
@@ -798,4 +798,84 @@ class ConcurrentWormholeTest {
           }
         });
   }
+
+  @RepeatedTest(10000)
+  void concurrentPutAndScan_ShouldReturnProperValues() throws Exception {
+    withRegisteredWormhole(
+        () -> {
+          // Arrange
+          assertThat(wormhole.put(10, 100)).isNull();
+          assertThat(wormhole.put(11, 110)).isNull();
+
+          ExecutorService executorService = Executors.newFixedThreadPool(3);
+          List<Future<?>> futures = new ArrayList<>();
+          CyclicBarrier barrier1 = new CyclicBarrier(3);
+          CyclicBarrier barrier2 = new CyclicBarrier(3);
+
+          try {
+            // Act
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier1.await();
+                              assertThat(wormhole.put(9, 90)).isNull();
+                              barrier2.await();
+                              List<Integer> scanned = new ArrayList<>();
+                              wormhole.scan(2, 15, true, (k, v) -> scanned.add(v));
+                              assertThat(scanned)
+                                  .isIn(
+                                      Arrays.asList(90, 100, 110, 130),
+                                      Arrays.asList(70, 90, 100, 110, 130));
+                              return null;
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier1.await();
+                              List<Integer> scanned = new ArrayList<>();
+                              wormhole.scan(6, 16, true, (k, v) -> scanned.add(v));
+                              assertThat(scanned)
+                                  .isIn(
+                                      Arrays.asList(100, 110),
+                                      Arrays.asList(90, 100, 110),
+                                      Arrays.asList(100, 110, 130),
+                                      Arrays.asList(90, 100, 110, 130));
+                              barrier2.await();
+                              assertThat(wormhole.put(7, 70)).isNull();
+                              return null;
+                            })));
+            futures.add(
+                executorService.submit(
+                    () ->
+                        withRegisteredWormhole(
+                            () -> {
+                              barrier1.await();
+                              assertThat(wormhole.put(13, 130)).isNull();
+                              barrier2.await();
+                              return null;
+                            })));
+
+            // Assert
+            for (Future<?> future : futures) {
+              future.get(5, TimeUnit.SECONDS);
+            }
+            assertThat(wormhole.get(7)).isEqualTo(70);
+            assertThat(wormhole.get(9)).isEqualTo(90);
+            assertThat(wormhole.get(10)).isEqualTo(100);
+            assertThat(wormhole.get(11)).isEqualTo(110);
+            assertThat(wormhole.get(13)).isEqualTo(130);
+
+            return null;
+          } finally {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+              executorService.shutdownNow();
+            }
+          }
+        });
+  }
 }

--- a/src/test/java/org/komamitsu/wormhole4j/SimpleWormholeForIntKeyTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/SimpleWormholeForIntKeyTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Mitsunori Komatsu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.komamitsu.wormhole4j;
+
+import org.junit.jupiter.api.BeforeEach;
+
+class SimpleWormholeForIntKeyTest extends WormholeForIntKeyTest {
+  @BeforeEach
+  void setUp() {
+    wormholeForIntValue =
+        new WormholeBuilder.ForIntKey<Integer>()
+            .setLeafNodeSize(leafNodeSize)
+            .setDebugMode(true)
+            .build();
+
+    wormholeForStrValue =
+        new WormholeBuilder.ForIntKey<String>()
+            .setLeafNodeSize(leafNodeSize)
+            .setDebugMode(true)
+            .build();
+  }
+}

--- a/src/test/java/org/komamitsu/wormhole4j/SimpleWormholeForLongKeyTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/SimpleWormholeForLongKeyTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Mitsunori Komatsu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.komamitsu.wormhole4j;
+
+import org.junit.jupiter.api.BeforeEach;
+
+class SimpleWormholeForLongKeyTest extends WormholeForLongKeyTest {
+  @BeforeEach
+  void setUp() {
+    wormholeForIntValue =
+        new WormholeBuilder.ForLongKey<Integer>()
+            .setLeafNodeSize(leafNodeSize)
+            .setDebugMode(true)
+            .build();
+
+    wormholeForStrValue =
+        new WormholeBuilder.ForLongKey<String>()
+            .setLeafNodeSize(leafNodeSize)
+            .setDebugMode(true)
+            .build();
+  }
+}

--- a/src/test/java/org/komamitsu/wormhole4j/SimpleWormholeForStringKeyTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/SimpleWormholeForStringKeyTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Mitsunori Komatsu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.komamitsu.wormhole4j;
+
+import org.junit.jupiter.api.BeforeEach;
+
+class SimpleWormholeForStringKeyTest extends WormholeForStringKeyTest {
+  @BeforeEach
+  void setUp() {
+    wormholeForIntValue =
+        new WormholeBuilder.ForStringKey<Integer>()
+            .setLeafNodeSize(leafNodeSize)
+            .setDebugMode(true)
+            .build();
+
+    wormholeForStrValue =
+        new WormholeBuilder.ForStringKey<String>()
+            .setLeafNodeSize(leafNodeSize)
+            .setDebugMode(true)
+            .build();
+  }
+}

--- a/src/test/java/org/komamitsu/wormhole4j/WormholeForIntKeyTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/WormholeForIntKeyTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -32,7 +31,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 @ParameterizedClass
 @ValueSource(ints = {3, 8, 128})
-class WormholeForIntKeyTest {
+abstract class WormholeForIntKeyTest {
   @Parameter int leafNodeSize;
 
   class Common {
@@ -41,23 +40,8 @@ class WormholeForIntKeyTest {
     }
   }
 
-  private Wormhole<Integer, Integer> wormholeForIntValue;
-  private Wormhole<Integer, String> wormholeForStrValue;
-
-  @BeforeEach
-  void setUp() {
-    wormholeForIntValue =
-        new WormholeBuilder.ForIntKey<Integer>()
-            .setLeafNodeSize(leafNodeSize)
-            .setDebugMode(true)
-            .build();
-
-    wormholeForStrValue =
-        new WormholeBuilder.ForIntKey<String>()
-            .setLeafNodeSize(leafNodeSize)
-            .setDebugMode(true)
-            .build();
-  }
+  protected Wormhole<Integer, Integer> wormholeForIntValue;
+  protected Wormhole<Integer, String> wormholeForStrValue;
 
   @Test
   void givenConcurrentAndDebugModeEnabled_ShouldThrowException() {

--- a/src/test/java/org/komamitsu/wormhole4j/WormholeForLongKeyTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/WormholeForLongKeyTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -32,7 +31,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 @ParameterizedClass
 @ValueSource(ints = {3, 8, 128})
-class WormholeForLongKeyTest {
+abstract class WormholeForLongKeyTest {
   @Parameter int leafNodeSize;
 
   class Common {
@@ -41,23 +40,8 @@ class WormholeForLongKeyTest {
     }
   }
 
-  private Wormhole<Long, Integer> wormholeForIntValue;
-  private Wormhole<Long, String> wormholeForStrValue;
-
-  @BeforeEach
-  void setUp() {
-    wormholeForIntValue =
-        new WormholeBuilder.ForLongKey<Integer>()
-            .setLeafNodeSize(leafNodeSize)
-            .setDebugMode(true)
-            .build();
-
-    wormholeForStrValue =
-        new WormholeBuilder.ForLongKey<String>()
-            .setLeafNodeSize(leafNodeSize)
-            .setDebugMode(true)
-            .build();
-  }
+  protected Wormhole<Long, Integer> wormholeForIntValue;
+  protected Wormhole<Long, String> wormholeForStrValue;
 
   @Test
   void givenConcurrentAndDebugModeEnabled_ShouldThrowException() {

--- a/src/test/java/org/komamitsu/wormhole4j/WormholeForStringKeyTest.java
+++ b/src/test/java/org/komamitsu/wormhole4j/WormholeForStringKeyTest.java
@@ -23,7 +23,6 @@ import static org.komamitsu.wormhole4j.TestHelpers.genRandomKey;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -33,7 +32,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 @ParameterizedClass
 @ValueSource(ints = {3, 8, 128})
-class WormholeForStringKeyTest {
+abstract class WormholeForStringKeyTest {
   @Parameter int leafNodeSize;
 
   class Common {
@@ -42,23 +41,8 @@ class WormholeForStringKeyTest {
     }
   }
 
-  private Wormhole<String, Integer> wormholeForIntValue;
-  private Wormhole<String, String> wormholeForStrValue;
-
-  @BeforeEach
-  void setUp() {
-    wormholeForIntValue =
-        new WormholeBuilder.ForStringKey<Integer>()
-            .setLeafNodeSize(leafNodeSize)
-            .setDebugMode(true)
-            .build();
-
-    wormholeForStrValue =
-        new WormholeBuilder.ForStringKey<String>()
-            .setLeafNodeSize(leafNodeSize)
-            .setDebugMode(true)
-            .build();
-  }
+  protected Wormhole<String, Integer> wormholeForIntValue;
+  protected Wormhole<String, String> wormholeForStrValue;
 
   @Test
   void givenConcurrentAndDebugModeEnabled_ShouldThrowException() {

--- a/src/test/kotlin/org/komamitsu/wormhole4j/WormholeTest.kt
+++ b/src/test/kotlin/org/komamitsu/wormhole4j/WormholeTest.kt
@@ -64,8 +64,8 @@ class WormholeTest {
     fun stressTest() = StressOptions()
         .sequentialSpecification(SequentialMap::class.java)
         .threads(3)
-        .invocationsPerIteration(100)
-        .iterations(100)
+        .invocationsPerIteration(40)
+        .iterations(40)
         .check(this::class)
 
     class SequentialMap {

--- a/src/test/kotlin/org/komamitsu/wormhole4j/WormholeTest.kt
+++ b/src/test/kotlin/org/komamitsu/wormhole4j/WormholeTest.kt
@@ -64,8 +64,8 @@ class WormholeTest {
     fun stressTest() = StressOptions()
         .sequentialSpecification(SequentialMap::class.java)
         .threads(3)
-        .invocationsPerIteration(40)
-        .iterations(40)
+        .invocationsPerIteration(100)
+        .iterations(100)
         .check(this::class)
 
     class SequentialMap {

--- a/src/test/kotlin/org/komamitsu/wormhole4j/WormholeTest.kt
+++ b/src/test/kotlin/org/komamitsu/wormhole4j/WormholeTest.kt
@@ -26,23 +26,33 @@ import java.util.TreeMap
 class WormholeTest {
     private val wormhole = WormholeBuilder.ForIntKey<Int>().setConcurrent(true).setLeafNodeSize(4).build()
 
+    fun ensureThreadRegistered() {
+        if (!wormhole.isThreadRegistered()) {
+            wormhole.register()
+        }
+    }
+
     @Operation(params = ["key", "value"])
     fun put(key: Int, value: Int): Int? {
+        ensureThreadRegistered()
         return wormhole.put(key, value)
     }
 
     @Operation(params = ["key"])
     fun get(key: Int): Int? {
+        ensureThreadRegistered()
         return wormhole.get(key)
     }
 
     @Operation(params = ["key"])
     fun delete(key: Int): Boolean {
+        ensureThreadRegistered()
         return wormhole.delete(key)
     }
 
     @Operation(params = ["key1", "key2"])
     fun scan(key1: Int, key2: Int): List<Int> {
+        ensureThreadRegistered()
         val (startKey, endKey) = if (key1 < key2) Pair(key1, key2) else Pair(key2, key1)
         val result = ArrayList<Int>()
         wormhole.scan(startKey, endKey, true) { _, v ->
@@ -56,8 +66,8 @@ class WormholeTest {
     fun stressTest() = StressOptions()
         .sequentialSpecification(SequentialMap::class.java)
         .threads(3)
-        .invocationsPerIteration(20)
-        .iterations(100)
+        .invocationsPerIteration(40)
+        .iterations(40)
         .check(this::class)
 
     class SequentialMap {

--- a/src/test/kotlin/org/komamitsu/wormhole4j/WormholeTest.kt
+++ b/src/test/kotlin/org/komamitsu/wormhole4j/WormholeTest.kt
@@ -27,9 +27,7 @@ class WormholeTest {
     private val wormhole = WormholeBuilder.ForIntKey<Int>().setConcurrent(true).setLeafNodeSize(4).build()
 
     fun ensureThreadRegistered() {
-        if (!wormhole.isThreadRegistered()) {
-            wormhole.register()
-        }
+        wormhole.registerThread()
     }
 
     @Operation(params = ["key", "value"])


### PR DESCRIPTION
This PR replaces the current pessimistic locks with QSBR RCU based concurrency support.